### PR TITLE
fix: show real reviewCount on search cards, hide count on favorites w…

### DIFF
--- a/src/components/BusinessCard.tsx
+++ b/src/components/BusinessCard.tsx
@@ -9,7 +9,7 @@ interface BusinessCardProps {
   name: string;
   category: string;
   rating: number;
-  reviewCount: number;
+  reviewCount?: number;
   distance: string;
   image: string;
   tags: string[];
@@ -89,7 +89,9 @@ export const BusinessCard = ({
           <div className="flex items-center gap-1">
             <Star className="h-4 w-4 fill-yellow-500 text-yellow-500" />
             <span className="font-medium text-foreground">{rating.toFixed(1)}</span>
-            <span className="text-muted-foreground">({reviewCount})</span>
+            {reviewCount !== undefined && (
+              <span className="text-muted-foreground">({reviewCount})</span>
+            )}
           </div>
           {distance && (
             <div className="flex items-center gap-1 text-primary">

--- a/src/hooks/useBusinessSearch.ts
+++ b/src/hooks/useBusinessSearch.ts
@@ -10,6 +10,7 @@ export interface BusinessSearchResult {
     name: string;
     category: string;
     rating: number;
+    reviewCount: number;
     tags: string[];
     verified: boolean;
     /** First image URL, if any */
@@ -89,6 +90,7 @@ export function useBusinessSearch(): UseBusinessSearchResult {
                         b.businessType ||
                         'Business',
                     rating: typeof b.averageRating === 'number' ? b.averageRating : 0,
+                    reviewCount: typeof b.reviewCount === 'number' ? b.reviewCount : 0,
                     tags: b.tags ?? [],
                     verified: b.verified ?? false,
                     image: Array.isArray(b.images) && b.images.length > 0

--- a/src/pages/Favorites.tsx
+++ b/src/pages/Favorites.tsx
@@ -171,7 +171,6 @@ const Favorites = () => {
                     name={fav.businessName}
                     category={fav.businessCategory}
                     rating={fav.businessRating}
-                    reviewCount={0}
                     distance={getDistanceLabel(fav.businessLatitude, fav.businessLongitude)}
                     image={
                       fav.businessImage ||

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -173,7 +173,7 @@ const Search = () => {
                 name={business.name}
                 category={business.category}
                 rating={business.rating}
-                reviewCount={0}
+                reviewCount={business.reviewCount}
                 distance={getDistanceLabel(business.latitude, business.longitude)}
                 image={
                   business.image ??


### PR DESCRIPTION
Fixes business cards on the Search page showing "(0)" reviews even when reviews exist.

- Added `reviewCount` to `BusinessSearchResult` and mapped it from the `Business` record in `useBusinessSearch`
- Search page now passes the real count to each `BusinessCard`
- Made `reviewCount` optional on `BusinessCard` — Favorites cards omit it since the favorited snapshot doesn't store a count (and it would go stale)