### PR TITLE
Backend Sprint 8: secure moderation and flagging workflows (create/list/resolve/count)

### DIFF
--- a/amplify/backend.ts
+++ b/amplify/backend.ts
@@ -2,11 +2,13 @@ import { defineBackend } from '@aws-amplify/backend';
 import { auth } from './auth/resource';
 import { data } from './data/resource';
 import { postConfirmation } from './functions/post-confirmation/resource';
+import { moderation } from './functions/moderation/resource';
 import { storage } from './storage/resource';
 
 defineBackend({
   auth,
   data,
   postConfirmation,
+  moderation,
   storage,
 });

--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -1,5 +1,6 @@
 import { a, defineData, type ClientSchema } from '@aws-amplify/backend';
 import { postConfirmation } from '../functions/post-confirmation/resource';
+import { moderation } from '../functions/moderation/resource';
 
 /**
  * BE-1.4: Auth Middleware via Authorization Rules
@@ -10,6 +11,37 @@ import { postConfirmation } from '../functions/post-confirmation/resource';
  * - Rules are reusable across all models
  */
 const schema = a.schema({
+  FlagTargetDetails: a.customType({
+    businessId: a.string(),
+    businessName: a.string(),
+    reviewText: a.string(),
+    reviewAuthorName: a.string(),
+  }),
+
+  FlagAdminView: a.customType({
+    id: a.id().required(),
+    targetType: a.string().required(),
+    targetId: a.string().required(),
+    reason: a.string().required(),
+    details: a.string(),
+    status: a.string().required(),
+    reporterId: a.string().required(),
+    reporterName: a.string(),
+    targetName: a.string(),
+    resolvedBy: a.string(),
+    resolvedAt: a.datetime(),
+    adminNotes: a.string(),
+    createdAt: a.datetime().required(),
+    updatedAt: a.datetime().required(),
+    targetDetails: a.ref('FlagTargetDetails'),
+  }),
+
+  FlagCounts: a.customType({
+    total: a.integer().required(),
+    pending: a.integer().required(),
+    resolved: a.integer().required(),
+  }),
+
   User: a.model({
     name: a.string().required(),
     email: a.string().required(),
@@ -97,8 +129,8 @@ const schema = a.schema({
     resolvedAt: a.datetime(),
     adminNotes: a.string(),
   }).authorization((allow) => [
-    allow.owner().to(['create', 'read']),
-    allow.authenticated().to(['read', 'update']),
+    // Flags are created and moderated via custom operations to enforce validation and admin checks.
+    allow.owner().to(['read']),
   ]),
 
   /**
@@ -128,8 +160,58 @@ const schema = a.schema({
   }).authorization((allow) => [
     allow.owner(),
   ]),
+
+  /**
+   * BE-8.2 + BE-8.5: Validated flag creation with duplicate prevention.
+   */
+  createFlag: a
+    .mutation()
+    .arguments({
+      targetType: a.string().required(), // BUSINESS | REVIEW
+      targetId: a.id().required(),
+      reason: a.string().required(),
+      details: a.string(),
+    })
+    .returns(a.ref('FlagAdminView'))
+    .authorization((allow) => [allow.authenticated()])
+    .handler(a.handler.function(moderation)),
+
+  /**
+   * BE-8.3: Admin queue retrieval for unresolved/reported content.
+   */
+  listFlagsForAdmin: a
+    .query()
+    .arguments({
+      status: a.string(), // defaults to PENDING in resolver
+    })
+    .returns(a.ref('FlagAdminView').array())
+    .authorization((allow) => [allow.authenticated()])
+    .handler(a.handler.function(moderation)),
+
+  /**
+   * BE-8.4: Admin-only resolution flow.
+   */
+  resolveFlag: a
+    .mutation()
+    .arguments({
+      flagId: a.id().required(),
+      adminNotes: a.string(),
+    })
+    .returns(a.ref('FlagAdminView'))
+    .authorization((allow) => [allow.authenticated()])
+    .handler(a.handler.function(moderation)),
+
+  /**
+   * BE-8.6: Optional moderation insights for prioritization.
+   */
+  flagCountsForAdmin: a
+    .query()
+    .returns(a.ref('FlagCounts'))
+    .authorization((allow) => [allow.authenticated()])
+    .handler(a.handler.function(moderation)),
 }).authorization((allow) => [
   allow.resource(postConfirmation).to(['mutate']),
+  allow.resource(moderation).to(['query', 'mutate']),
 ]);
 
 export type Schema = ClientSchema<typeof schema>;

--- a/amplify/functions/moderation/handler.ts
+++ b/amplify/functions/moderation/handler.ts
@@ -1,0 +1,537 @@
+import type { AppSyncResolverEvent } from 'aws-lambda';
+import { Amplify } from 'aws-amplify';
+import { generateClient } from 'aws-amplify/api';
+import outputs from '../../../amplify_outputs.json';
+
+Amplify.configure(outputs, { ssr: true });
+const client = generateClient();
+
+type Identity = {
+  sub?: string;
+  username?: string;
+  claims?: Record<string, unknown>;
+};
+
+type ResolverEvent = AppSyncResolverEvent<Record<string, unknown>>;
+
+type TargetType = 'BUSINESS' | 'REVIEW';
+
+type FlagRecord = {
+  id: string;
+  targetType: TargetType;
+  targetId: string;
+  reason: string;
+  details?: string | null;
+  status: string;
+  reporterId: string;
+  reporterName?: string | null;
+  targetName?: string | null;
+  resolvedBy?: string | null;
+  resolvedAt?: string | null;
+  adminNotes?: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type TargetDetails = {
+  businessId?: string;
+  businessName?: string;
+  reviewText?: string;
+  reviewAuthorName?: string;
+};
+
+const VALID_TARGET_TYPES = new Set(['BUSINESS', 'REVIEW']);
+const VALID_RESOLVABLE_STATUSES = new Set(['PENDING', 'REVIEWED', 'DISMISSED', 'ACTION_TAKEN', 'RESOLVED']);
+
+export const handler = async (event: ResolverEvent) => {
+  const fieldName = event.info?.fieldName;
+
+  switch (fieldName) {
+    case 'createFlag':
+      return createFlag(event);
+    case 'listFlagsForAdmin':
+      return listFlagsForAdmin(event);
+    case 'resolveFlag':
+      return resolveFlag(event);
+    case 'flagCountsForAdmin':
+      return flagCountsForAdmin(event);
+    default:
+      throw new Error(`Unsupported moderation operation: ${String(fieldName)}`);
+  }
+};
+
+async function createFlag(event: ResolverEvent) {
+  const identity = requireAuthenticatedUser(event);
+  const reporterId = identity.sub ?? identity.username;
+
+  if (!reporterId) {
+    throw new Error('Unable to determine authenticated user identity');
+  }
+
+  const targetType = String(event.arguments?.targetType ?? '').toUpperCase();
+  const targetId = String(event.arguments?.targetId ?? '').trim();
+  const reason = String(event.arguments?.reason ?? '').trim();
+  const detailsRaw = event.arguments?.details;
+  const details = typeof detailsRaw === 'string' && detailsRaw.trim().length > 0
+    ? detailsRaw.trim()
+    : null;
+
+  if (!VALID_TARGET_TYPES.has(targetType)) {
+    throw new Error('Invalid targetType. Expected BUSINESS or REVIEW.');
+  }
+
+  if (!targetId) {
+    throw new Error('targetId is required.');
+  }
+
+  if (!reason) {
+    throw new Error('reason is required.');
+  }
+
+  const target = await getTarget(targetType as TargetType, targetId);
+  if (!target.exists) {
+    throw new Error(`${targetType} with id ${targetId} was not found.`);
+  }
+
+  const duplicate = await findExistingPendingFlag(reporterId, targetType as TargetType, targetId);
+  if (duplicate) {
+    throw new Error('You already have an open flag for this item.');
+  }
+
+  const createRes = await graphql<{ createFlag: FlagRecord }>(
+    `
+      mutation CreateFlag($input: CreateFlagInput!) {
+        createFlag(input: $input) {
+          id
+          targetType
+          targetId
+          reason
+          details
+          status
+          reporterId
+          reporterName
+          targetName
+          resolvedBy
+          resolvedAt
+          adminNotes
+          createdAt
+          updatedAt
+        }
+      }
+    `,
+    {
+      input: {
+        targetType,
+        targetId,
+        reason,
+        details,
+        status: 'PENDING',
+        reporterId,
+        reporterName: identity.username ?? null,
+        targetName: target.targetName ?? null,
+      },
+    }
+  );
+
+  const created = createRes.createFlag;
+
+  await incrementTargetFlagCount(targetType as TargetType, targetId, target.flagCount ?? 0);
+  await createAdminNotification(
+    'FLAG_CREATED',
+    `New ${targetType.toLowerCase()} flag`,
+    `${targetType} ${target.targetName ?? targetId} was flagged for: ${reason}`,
+    created.id,
+    'FLAG'
+  );
+
+  return {
+    ...created,
+    targetDetails: target.details,
+  };
+}
+
+async function listFlagsForAdmin(event: ResolverEvent) {
+  requireAdminUser(event);
+
+  const requestedStatus = event.arguments?.status;
+  const status = typeof requestedStatus === 'string' && requestedStatus.trim().length > 0
+    ? requestedStatus.trim().toUpperCase()
+    : 'PENDING';
+
+  if (!VALID_RESOLVABLE_STATUSES.has(status)) {
+    throw new Error('Invalid status filter.');
+  }
+
+  const flags = await listAllFlags(status);
+
+  const enriched = await Promise.all(
+    flags.map(async (flag) => {
+      const target = await getTarget(flag.targetType, flag.targetId);
+      return {
+        ...flag,
+        targetDetails: target.details,
+      };
+    })
+  );
+
+  return enriched;
+}
+
+async function resolveFlag(event: ResolverEvent) {
+  const identity = requireAdminUser(event);
+  const flagId = String(event.arguments?.flagId ?? '').trim();
+  const adminNotesRaw = event.arguments?.adminNotes;
+  const adminNotes = typeof adminNotesRaw === 'string' && adminNotesRaw.trim().length > 0
+    ? adminNotesRaw.trim()
+    : null;
+
+  if (!flagId) {
+    throw new Error('flagId is required.');
+  }
+
+  const existing = await getFlagById(flagId);
+  if (!existing) {
+    throw new Error(`Flag ${flagId} was not found.`);
+  }
+
+  const resolvedBy = identity.sub ?? identity.username;
+  if (!resolvedBy) {
+    throw new Error('Unable to determine admin identity.');
+  }
+
+  const now = new Date().toISOString();
+  const updateRes = await graphql<{ updateFlag: FlagRecord }>(
+    `
+      mutation ResolveFlag($input: UpdateFlagInput!) {
+        updateFlag(input: $input) {
+          id
+          targetType
+          targetId
+          reason
+          details
+          status
+          reporterId
+          reporterName
+          targetName
+          resolvedBy
+          resolvedAt
+          adminNotes
+          createdAt
+          updatedAt
+        }
+      }
+    `,
+    {
+      input: {
+        id: flagId,
+        status: 'RESOLVED',
+        resolvedBy,
+        resolvedAt: now,
+        adminNotes,
+      },
+    }
+  );
+
+  const updated = updateRes.updateFlag;
+  await createAdminNotification(
+    'FLAG_RESOLVED',
+    'Flag resolved',
+    `Flag ${flagId} was resolved by an admin.`,
+    flagId,
+    'FLAG'
+  );
+
+  const target = await getTarget(updated.targetType, updated.targetId);
+  return {
+    ...updated,
+    targetDetails: target.details,
+  };
+}
+
+async function flagCountsForAdmin(event: ResolverEvent) {
+  requireAdminUser(event);
+
+  const all = await listAllFlags();
+  const pending = all.filter((flag) => flag.status === 'PENDING').length;
+  const resolved = all.filter((flag) => flag.status === 'RESOLVED').length;
+
+  return {
+    total: all.length,
+    pending,
+    resolved,
+  };
+}
+
+function requireAuthenticatedUser(event: ResolverEvent): Identity {
+  const identity = event.identity as Identity | null;
+  if (!identity) {
+    throw new Error('Authentication required.');
+  }
+  return identity;
+}
+
+function requireAdminUser(event: ResolverEvent): Identity {
+  const identity = requireAuthenticatedUser(event);
+  const claims = identity.claims ?? {};
+
+  const customRole = String(claims['custom:role'] ?? '').toUpperCase();
+  const groupsClaim = claims['cognito:groups'];
+  const groups = Array.isArray(groupsClaim)
+    ? groupsClaim.map((g) => String(g).toUpperCase())
+    : String(groupsClaim ?? '')
+        .split(',')
+        .map((g) => g.trim().toUpperCase())
+        .filter(Boolean);
+
+  const isAdmin = customRole === 'ADMIN' || groups.includes('ADMIN');
+  if (!isAdmin) {
+    throw new Error('Admin access required.');
+  }
+
+  return identity;
+}
+
+async function findExistingPendingFlag(reporterId: string, targetType: TargetType, targetId: string) {
+  const result = await graphql<{ listFlags: { items: Array<{ id: string }> } }>(
+    `
+      query FindDuplicateFlag($filter: ModelFlagFilterInput, $limit: Int) {
+        listFlags(filter: $filter, limit: $limit) {
+          items {
+            id
+          }
+        }
+      }
+    `,
+    {
+      filter: {
+        reporterId: { eq: reporterId },
+        targetType: { eq: targetType },
+        targetId: { eq: targetId },
+        status: { eq: 'PENDING' },
+      },
+      limit: 1,
+    }
+  );
+
+  return (result.listFlags.items ?? [])[0] ?? null;
+}
+
+async function getFlagById(id: string): Promise<FlagRecord | null> {
+  const result = await graphql<{ getFlag: FlagRecord | null }>(
+    `
+      query GetFlag($id: ID!) {
+        getFlag(id: $id) {
+          id
+          targetType
+          targetId
+          reason
+          details
+          status
+          reporterId
+          reporterName
+          targetName
+          resolvedBy
+          resolvedAt
+          adminNotes
+          createdAt
+          updatedAt
+        }
+      }
+    `,
+    { id }
+  );
+
+  return result.getFlag;
+}
+
+async function listAllFlags(status?: string): Promise<FlagRecord[]> {
+  const items: FlagRecord[] = [];
+  let nextToken: string | null | undefined;
+
+  do {
+    const result = await graphql<{ listFlags: { items: FlagRecord[]; nextToken?: string | null } }>(
+      `
+        query ListFlags($filter: ModelFlagFilterInput, $limit: Int, $nextToken: String) {
+          listFlags(filter: $filter, limit: $limit, nextToken: $nextToken) {
+            items {
+              id
+              targetType
+              targetId
+              reason
+              details
+              status
+              reporterId
+              reporterName
+              targetName
+              resolvedBy
+              resolvedAt
+              adminNotes
+              createdAt
+              updatedAt
+            }
+            nextToken
+          }
+        }
+      `,
+      {
+        filter: status ? { status: { eq: status } } : undefined,
+        limit: 100,
+        nextToken,
+      }
+    );
+
+    items.push(...(result.listFlags.items ?? []));
+    nextToken = result.listFlags.nextToken;
+  } while (nextToken);
+
+  return items;
+}
+
+async function getTarget(targetType: TargetType, targetId: string): Promise<{
+  exists: boolean;
+  targetName?: string;
+  flagCount?: number;
+  details: TargetDetails;
+}> {
+  if (targetType === 'BUSINESS') {
+    const business = await graphql<{ getBusiness: { id: string; businessName?: string | null; flagCount?: number | null } | null }>(
+      `
+        query GetBusiness($id: ID!) {
+          getBusiness(id: $id) {
+            id
+            businessName
+            flagCount
+          }
+        }
+      `,
+      { id: targetId }
+    );
+
+    if (!business.getBusiness) {
+      return { exists: false, details: {} };
+    }
+
+    return {
+      exists: true,
+      targetName: business.getBusiness.businessName ?? undefined,
+      flagCount: business.getBusiness.flagCount ?? 0,
+      details: {
+        businessName: business.getBusiness.businessName ?? undefined,
+      },
+    };
+  }
+
+  const review = await graphql<{
+    getReview: {
+      id: string;
+      businessId: string;
+      authorName?: string | null;
+      text?: string | null;
+      flagCount?: number | null;
+    } | null;
+  }>(
+    `
+      query GetReview($id: ID!) {
+        getReview(id: $id) {
+          id
+          businessId
+          authorName
+          text
+          flagCount
+        }
+      }
+    `,
+    { id: targetId }
+  );
+
+  if (!review.getReview) {
+    return { exists: false, details: {} };
+  }
+
+  const excerpt = review.getReview.text
+    ? review.getReview.text.slice(0, 140)
+    : undefined;
+
+  return {
+    exists: true,
+    targetName: review.getReview.authorName ?? 'Review',
+    flagCount: review.getReview.flagCount ?? 0,
+    details: {
+      businessId: review.getReview.businessId,
+      reviewText: excerpt,
+      reviewAuthorName: review.getReview.authorName ?? undefined,
+    },
+  };
+}
+
+async function incrementTargetFlagCount(targetType: TargetType, targetId: string, currentFlagCount: number) {
+  const nextCount = (currentFlagCount || 0) + 1;
+
+  if (targetType === 'BUSINESS') {
+    await graphql(
+      `
+        mutation IncrementBusinessFlagCount($input: UpdateBusinessInput!) {
+          updateBusiness(input: $input) {
+            id
+          }
+        }
+      `,
+      { input: { id: targetId, flagCount: nextCount } }
+    );
+    return;
+  }
+
+  await graphql(
+    `
+      mutation IncrementReviewFlagCount($input: UpdateReviewInput!) {
+        updateReview(input: $input) {
+          id
+        }
+      }
+    `,
+    { input: { id: targetId, flagCount: nextCount } }
+  );
+}
+
+async function createAdminNotification(
+  type: string,
+  title: string,
+  message: string,
+  relatedId: string,
+  relatedType: string
+) {
+  await graphql(
+    `
+      mutation CreateAdminNotification($input: CreateAdminNotificationInput!) {
+        createAdminNotification(input: $input) {
+          id
+        }
+      }
+    `,
+    {
+      input: {
+        type,
+        title,
+        message,
+        relatedId,
+        relatedType,
+        read: false,
+      },
+    }
+  );
+}
+
+async function graphql<T>(query: string, variables?: Record<string, unknown>): Promise<T> {
+  const response = await client.graphql({
+    query,
+    variables,
+    authMode: 'iam',
+  } as never);
+
+  const errors = (response as { errors?: Array<{ message?: string }> }).errors;
+  if (errors && errors.length > 0) {
+    throw new Error(errors.map((err) => err.message ?? 'Unknown GraphQL error').join('; '));
+  }
+
+  return (response as { data: T }).data;
+}

--- a/amplify/functions/moderation/resource.ts
+++ b/amplify/functions/moderation/resource.ts
@@ -1,0 +1,10 @@
+import { defineFunction } from '@aws-amplify/backend';
+
+/**
+ * Central moderation function that powers secure flagging/admin moderation operations.
+ */
+export const moderation = defineFunction({
+  name: 'moderation',
+  entry: './handler.ts',
+  depsLockFilePath: '../../package-lock.json',
+});

--- a/scripts/pr-body.md
+++ b/scripts/pr-body.md
@@ -1,34 +1,70 @@
 ## Summary
 
-This branch implements three major user-facing feature areas on top of the existing business search and profile pages.
+This PR completes Backend Sprint 8 moderation/flagging hardening by moving moderation logic from client-driven flows into secure backend operations.
 
-### Reviews
-- **Amplify schema**: Added `Review` model (owner create/delete, authenticated + guest read) and `reviewCount` / `averageRating` recalculation on `Business`
-- **`useReviews` hook**: Fetches all reviews for a business; on submit creates a `Review` record then recalculates `Business.averageRating` and `Business.reviewCount`
-- **`ReviewForm` component**: Auth-gated — guests see a "Sign in to leave a review" prompt; authenticated users get a 1–5 interactive star selector, optional comment field, and a **"Include my name"** checkbox (checked by default). When checked, the display name is pulled from Cognito attributes and formatted as `First L.`; unchecked posts as `Anonymous Customer`
-- Reviews appear live on the business profile page beneath the existing preview card
+### BE-8.1 Flag Data Structure
+- Confirmed and retained existing `Flag` + `AdminNotification` models and `flagCount` on `Business`/`Review`
+- Added custom response types used by backend moderation APIs:
+	- `FlagTargetDetails`
+	- `FlagAdminView`
+	- `FlagCounts`
 
-### Search Filters & Distance
-- **`useUserLocation` hook**: Lazy geolocation — never auto-prompts; supports two input methods: browser GPS and zip code lookup via Nominatim (OpenStreetMap, no API key required)
-- **`SearchFilters` sheet**: Slide-over panel wired to the existing Filters button with category multi-select, minimum star rating picker, and sort-by radio (Relevance / Rating high to low / Distance near to far). When Distance is selected, the user can tap "Use GPS" or switch to a zip code input
-- **Haversine distance**: Calculated client-side from pre-stored `latitude`/`longitude` on each Business record; shown as `X.X mi` on every card when a location is set
-- **Addresses seeded**: All 6 businesses now have real DC/VA/MD street addresses and coordinates in DynamoDB. Addresses also display on each business profile contact card
+### BE-8.2 Create Flag Flow
+- Added `createFlag` custom mutation handled by moderation Lambda
+- Enforces authentication
+- Validates `targetType`, `targetId`, and non-empty `reason`
+- Verifies target exists (`BUSINESS` or `REVIEW`) before creating the flag
+- Creates flag with `PENDING` status
+- Increments target `flagCount`
+- Creates `AdminNotification` for new reports
 
-### Favorites
-- **Amplify schema**: Added `Favorite` model (owner-only) storing a denormalized business snapshot including lat/lng so distance can be shown without extra API calls
-- **`useFavorites` hook**: Loads the current user's favorites on mount; `toggleFavorite` adds or removes a record from DynamoDB. Unauthenticated users are not prompted
-- **Heart button on `BusinessCard`**: Converted from local state to controlled props (`isFavorite`, `onToggleFavorite`). For unauthenticated users, clicking the heart redirects to `/auth`
-- **Favorites page** (`/favorites`): Redirects guests to `/auth`; shows a grid of saved businesses with live distance labels; unfavoriting from this page removes the card immediately
+### BE-8.3 Admin Flag Retrieval
+- Added `listFlagsForAdmin` custom query handled by moderation Lambda
+- Enforces admin authorization (`custom:role` or `cognito:groups`)
+- Defaults to unresolved queue (`PENDING`) with optional status filtering
+- Returns enriched target context for moderation UI
 
-### Bug fix
-- Fixed an auth mode ordering bug where all data hooks tried `iam` first, which fails for signed-in users. The new priority is `userPool` then `iam` then `apiKey`, matching the Amplify authorization rules on each model
+### BE-8.4 Flag Resolution
+- Added `resolveFlag` custom mutation handled by moderation Lambda
+- Enforces admin authorization
+- Verifies flag exists
+- Updates status to `RESOLVED`
+- Stores `resolvedBy`, `resolvedAt`, and optional `adminNotes`
+- Creates `AdminNotification` for resolution event
 
-## Test plan
-- [ ] Sign in and navigate to a business profile — verify review form appears, star selector works, name toggles correctly, and submitting a review updates the rating
-- [ ] Sign out and verify the review form shows "Sign in to leave a review"
-- [ ] On the Search page, open Filters and select Distance — verify GPS prompt and zip code input both work and cards show distance in miles
-- [ ] Filter by category and minimum rating — verify results update correctly
-- [ ] Click the heart on a business card while signed in — verify it fills red and appears on `/favorites`
-- [ ] Click the heart again — verify it removes from favorites
-- [ ] Navigate to `/favorites` while signed out — verify redirect to `/auth`
-- [ ] Visit a business profile and verify the address appears in the Contact card
+### BE-8.5 Duplicate Flag Prevention
+- Backend guard prevents duplicate pending flags by the same user on the same target
+
+### BE-8.6 Optional Counts/Filtering
+- Added `flagCountsForAdmin` custom query returning:
+	- total
+	- pending
+	- resolved
+- Added status-based filtering support in admin flag retrieval
+
+## Security/Architecture Changes
+- Added dedicated moderation Lambda:
+	- `amplify/functions/moderation/resource.ts`
+	- `amplify/functions/moderation/handler.ts`
+- Registered moderation function in backend stack
+- Routed moderation flows through backend operations instead of direct model writes
+- Tightened `Flag` model auth to avoid bypassing backend moderation checks
+
+## Files Changed
+- `amplify/data/resource.ts`
+- `amplify/functions/moderation/resource.ts`
+- `amplify/functions/moderation/handler.ts`
+- `amplify/backend.ts`
+
+## Test Plan
+- [ ] Authenticated non-admin can create a flag for valid `BUSINESS` target
+- [ ] Authenticated non-admin can create a flag for valid `REVIEW` target
+- [ ] Create flag fails for invalid target ID
+- [ ] Create flag fails for invalid target type
+- [ ] Create flag fails for empty reason
+- [ ] Duplicate pending flag from same user/target is rejected
+- [ ] Non-admin cannot call `listFlagsForAdmin`
+- [ ] Admin can list pending flags and view enriched target details
+- [ ] Non-admin cannot call `resolveFlag`
+- [ ] Admin can resolve a flag and see `resolvedBy`/`resolvedAt` set
+- [ ] `flagCountsForAdmin` returns expected totals


### PR DESCRIPTION
Implemented backend moderation workflow by introducing a dedicated moderation Lambda and wiring secure custom GraphQL operations for flagging and admin review/resolution. The schema now exposes backend-enforced flows for creating flags, retrieving admin flag queues, resolving flags, and fetching moderation counts, while backend registration was updated to include the new function.

Changes included:

Added moderation function:
resource.ts
handler.ts
Updated data schema and moderation operations:
resource.ts
Registered moderation function in backend:
backend.ts
Updated PR body template content:
pr-body.md