### PR TITLE
feat(chat): Gemini assistant with floating panel and env template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Google AI Studio / Gemini — used by the in-app assistant (src/lib/gemini-chat.ts).
+# For production, call Gemini from a trusted backend; do not ship long-lived keys in the browser.
+# Copy to `.env` and fill in (never commit real keys).
+VITE_GEMINI_API_KEY=
+
+# Optional. Default in code: gemini-2.5-flash (2.0 Flash is unavailable for new API keys)
+# VITE_GEMINI_MODEL=gemini-2.5-flash-lite

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,11 @@ dist
 dist-ssr
 *.local
 
+# Secrets and local env (never commit API keys)
+.env
+.env.*
+!.env.example
+
 # Amplify sandbox build artifacts (auto-generated, environment-specific)
 .amplify/artifacts/
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@aws-amplify/ui-react": "^6.14.0",
         "@aws-sdk/client-ses": "^3.1024.0",
+        "@google/generative-ai": "^0.24.1",
         "@hookform/resolvers": "^3.10.0",
         "@radix-ui/react-accordion": "^1.2.11",
         "@radix-ui/react-alert-dialog": "^1.1.14",
@@ -22507,6 +22508,15 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
+    },
+    "node_modules/@google/generative-ai": {
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.24.1.tgz",
+      "integrity": "sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@graphql-codegen/core": {
       "version": "2.6.8",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@aws-amplify/ui-react": "^6.14.0",
     "@aws-sdk/client-ses": "^3.1024.0",
+    "@google/generative-ai": "^0.24.1",
     "@hookform/resolvers": "^3.10.0",
     "@radix-ui/react-accordion": "^1.2.11",
     "@radix-ui/react-alert-dialog": "^1.1.14",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import RegisterBusiness from "./pages/RegisterBusiness";
 import BusinessProfilePage from "./pages/BusinessProfile";
 import NotFound from "./pages/NotFound";
 import Profile from "./pages/Profile";
+import { UpliftChatAssistant } from "@/components/chat/UpliftChatAssistant";
 
 const queryClient = new QueryClient();
 
@@ -44,6 +45,7 @@ const App = () => (
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
           </Routes>
+        <UpliftChatAssistant />
         </BrowserRouter>
       </TooltipProvider>
     </AuthProvider>

--- a/src/components/chat/UpliftChatAssistant.tsx
+++ b/src/components/chat/UpliftChatAssistant.tsx
@@ -1,0 +1,209 @@
+import { useCallback, useRef, useState } from "react";
+import type { ChatSession } from "@google/generative-ai";
+import { Bot, Loader2, Send } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { cn } from "@/lib/utils";
+import { createUpliftChatSession, isGeminiConfigured, sendUpliftMessage } from "@/lib/gemini-chat";
+
+type UiMessage = { role: "user" | "assistant"; text: string };
+
+const SUGGESTED_PROMPTS = [
+  "How do I find businesses near me?",
+  "What does verified mean here?",
+  "How can a business join Uplift?",
+] as const;
+
+/**
+ * Floating assistant: FAB opens a compact side card (not full-height). Gemini runs in the
+ * browser via `VITE_GEMINI_API_KEY` (dev / prototypes only — use a server proxy before production).
+ */
+export function UpliftChatAssistant() {
+  const [open, setOpen] = useState(false);
+  const [input, setInput] = useState("");
+  const [messages, setMessages] = useState<UiMessage[]>([]);
+  const [sending, setSending] = useState(false);
+  const chatRef = useRef<ChatSession | null>(null);
+
+  const configured = isGeminiConfigured();
+
+  const resetConversation = useCallback(() => {
+    chatRef.current = null;
+    setMessages([]);
+  }, []);
+
+  const sendText = useCallback(
+    async (raw: string) => {
+      const text = raw.trim();
+      if (!text || sending) return;
+      if (!configured) {
+        toast.error("Add VITE_GEMINI_API_KEY to your .env file to enable the assistant.");
+        return;
+      }
+
+      setMessages((prev) => [...prev, { role: "user", text }]);
+      setInput("");
+      setSending(true);
+
+      try {
+        if (!chatRef.current) {
+          chatRef.current = createUpliftChatSession();
+        }
+        const reply = await sendUpliftMessage(chatRef.current, text);
+        setMessages((prev) => [...prev, { role: "assistant", text: reply }]);
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : "Something went wrong.";
+        toast.error("Assistant could not reply", { description: msg });
+        setMessages((prev) => prev.slice(0, -1));
+      } finally {
+        setSending(false);
+      }
+    },
+    [configured, sending],
+  );
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    void sendText(input);
+  };
+
+  return (
+    <>
+      <Button
+        type="button"
+        size="icon"
+        onClick={() => setOpen(true)}
+        className={cn(
+          "fixed bottom-5 right-5 z-40 h-14 w-14 rounded-full shadow-lg",
+          "bg-primary text-primary-foreground hover:bg-primary-hover",
+          open && "hidden",
+        )}
+        aria-label="Open Uplift assistant"
+      >
+        <Bot className="h-7 w-7" strokeWidth={1.75} />
+      </Button>
+
+      <Sheet modal={false} open={open} onOpenChange={setOpen}>
+        <SheetContent
+          side="right"
+          overlayClassName="bg-transparent pointer-events-none"
+          onInteractOutside={(e) => e.preventDefault()}
+          onPointerDownOutside={(e) => e.preventDefault()}
+          className={cn(
+            "flex flex-col gap-0 overflow-hidden p-0",
+            /* Floating card — same corner as the FAB (FAB is hidden while open) */
+            "left-auto top-auto h-[min(31rem,calc(100vh-7rem))] w-[min(22rem,calc(100vw-2rem))]",
+            "bottom-5 right-4 sm:right-5 sm:max-w-none",
+            "rounded-2xl border border-border shadow-xl",
+          )}
+        >
+          <SheetHeader className="space-y-1 border-b border-border px-4 py-4 text-left">
+            <div className="flex items-start gap-3 pr-8">
+              <div
+                className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-primary/25 text-primary-foreground"
+                aria-hidden
+              >
+                <Bot className="h-5 w-5 text-foreground" strokeWidth={1.75} />
+              </div>
+              <div className="min-w-0 flex-1">
+                <SheetTitle className="text-base">Uplift assistant</SheetTitle>
+                <SheetDescription className="text-xs text-muted-foreground">
+                  Ask how to use the app or get ideas for supporting minority-owned businesses.
+                </SheetDescription>
+              </div>
+            </div>
+            {messages.length > 0 && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-8 self-start px-2 text-xs text-muted-foreground"
+                onClick={resetConversation}
+              >
+                Clear chat
+              </Button>
+            )}
+          </SheetHeader>
+
+          {!configured && (
+            <p className="border-b border-border bg-muted/50 px-4 py-3 text-xs text-muted-foreground">
+              Set <code className="rounded bg-muted px-1 py-0.5 font-mono text-[11px]">VITE_GEMINI_API_KEY</code> in{" "}
+              <code className="rounded bg-muted px-1 py-0.5 font-mono text-[11px]">.env</code> and restart{" "}
+              <code className="rounded bg-muted px-1 py-0.5 font-mono text-[11px]">npm run dev</code>. Use a backend
+              proxy before shipping to production.
+            </p>
+          )}
+
+          <div className="min-h-0 flex-1 space-y-3 overflow-y-auto px-4 py-4">
+            {messages.length === 0 && (
+              <p className="text-sm text-muted-foreground">
+                Try one of the suggestions below, or type your own question.
+              </p>
+            )}
+            {messages.map((m, i) => (
+              <div
+                key={`${i}-${m.role}`}
+                className={cn(
+                  "rounded-2xl px-3 py-2 text-sm leading-relaxed",
+                  m.role === "user" ? "ml-6 bg-primary/15 text-foreground" : "mr-4 bg-muted text-foreground",
+                )}
+              >
+                {m.text}
+              </div>
+            ))}
+            {sending && (
+              <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+                Thinking…
+              </div>
+            )}
+          </div>
+
+          <div className="space-y-2 border-t border-border px-4 py-3">
+            {messages.length === 0 && (
+              <div className="flex flex-wrap gap-2">
+                {SUGGESTED_PROMPTS.map((label) => (
+                  <button
+                    key={label}
+                    type="button"
+                    disabled={sending || !configured}
+                    onClick={() => void sendText(label)}
+                    className={cn(
+                      "rounded-full border border-primary/40 bg-primary/5 px-3 py-1.5 text-left text-xs font-medium text-foreground",
+                      "transition-colors hover:bg-primary/10 disabled:pointer-events-none disabled:opacity-50",
+                    )}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+            )}
+
+            <form onSubmit={onSubmit} className="flex gap-2">
+              <Input
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                placeholder="Ask about Uplift…"
+                disabled={sending || !configured}
+                className="min-w-0 flex-1 rounded-full border-border bg-muted/80"
+                aria-label="Message to assistant"
+              />
+              <Button
+                type="submit"
+                size="icon"
+                disabled={sending || !input.trim() || !configured}
+                className="h-10 w-10 shrink-0 rounded-xl bg-primary text-primary-foreground hover:bg-primary-hover"
+                aria-label="Send message"
+              >
+                {sending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
+              </Button>
+            </form>
+          </div>
+        </SheetContent>
+      </Sheet>
+    </>
+  );
+}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -49,12 +49,14 @@ const sheetVariants = cva(
 
 interface SheetContentProps
   extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
-    VariantProps<typeof sheetVariants> {}
+    VariantProps<typeof sheetVariants> {
+  overlayClassName?: string;
+}
 
 const SheetContent = React.forwardRef<React.ElementRef<typeof SheetPrimitive.Content>, SheetContentProps>(
-  ({ side = "right", className, children, ...props }, ref) => (
+  ({ side = "right", className, overlayClassName, children, ...props }, ref) => (
     <SheetPortal>
-      <SheetOverlay />
+      <SheetOverlay className={overlayClassName} />
       <SheetPrimitive.Content ref={ref} className={cn(sheetVariants({ side }), className)} {...props}>
         {children}
         <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity data-[state=open]:bg-secondary hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">

--- a/src/lib/gemini-chat.ts
+++ b/src/lib/gemini-chat.ts
@@ -1,0 +1,43 @@
+import { GoogleGenerativeAI, type ChatSession } from "@google/generative-ai";
+
+/** Grounds the model in Uplift’s product; avoids inventing live user or business data. */
+export const UPLIFT_CHAT_SYSTEM_INSTRUCTION = `You are a helpful assistant embedded in Uplift, a web app that helps people discover and support minority-owned businesses. You are powered by Google's Gemini models via the app's integration—answer honestly if someone asks what you are or what powers you.
+
+How to reply:
+- Answer the user's actual question first, directly and literally. Do not ignore specific questions (e.g. "Are you using Gemini?") or replace them with a generic greeting or a vague "How can I help?" pitch.
+- Stay concise. One short paragraph is often enough unless they ask for detail.
+- Then, only if it fits, you may add one sentence tying back to Uplift.
+
+You are strong on:
+- How to use Discover / search, filters, favorites, business profiles, profile tabs, messaging (high level)
+- What verified businesses mean on the platform
+- How business owners can join / register (high level)
+- Ideas for supporting minority-owned and local businesses
+
+Rules:
+- Do not invent specific business names, addresses, hours, or live user/account data—you cannot see their screen or database.
+- If something needs their real data or the live catalog, say you cannot see it and name the screen to use (e.g. Discover, Profile).
+- For medical, legal, or financial decisions, suggest a qualified professional.`;
+
+export function isGeminiConfigured(): boolean {
+  return Boolean(import.meta.env.VITE_GEMINI_API_KEY?.trim());
+}
+
+export function createUpliftChatSession(): ChatSession {
+  const apiKey = import.meta.env.VITE_GEMINI_API_KEY?.trim();
+  if (!apiKey) {
+    throw new Error("MISSING_API_KEY");
+  }
+  const modelName = import.meta.env.VITE_GEMINI_MODEL?.trim() || "gemini-2.5-flash";
+  const genAI = new GoogleGenerativeAI(apiKey);
+  const model = genAI.getGenerativeModel({
+    model: modelName,
+    systemInstruction: UPLIFT_CHAT_SYSTEM_INSTRUCTION,
+  });
+  return model.startChat({ history: [] });
+}
+
+export async function sendUpliftMessage(chat: ChatSession, text: string): Promise<string> {
+  const result = await chat.sendMessage(text);
+  return result.response.text();
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,11 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_GEMINI_API_KEY?: string;
+  /** Optional override; defaults to gemini-2.5-flash in code. */
+  readonly VITE_GEMINI_MODEL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
Description
Adds an in-app Uplift assistant powered by Google Gemini: a floating bot button opens a compact card on the right (not a full-height sheet). The launcher hides while the panel is open; the backdrop is clear and does not blur the page—users close via the sheet X. Suggested prompts show only before the first message.

Setup
Copy .env.example → .env and set VITE_GEMINI_API_KEY (restart npm run dev).
Default model is gemini-2.5-flash (VITE_GEMINI_MODEL optional). gemini-2.0-flash is unavailable for new API keys.
Technical notes
Adds @google/generative-ai and src/lib/gemini-chat.ts with an Uplift-focused system instruction (direct answers, including meta questions about Gemini).
Extends SheetContent with optional overlayClassName for custom overlays.
.gitignore: ignore .env / .env.* except .env.example.

Security / follow-ups
VITE_* keys are exposed in client bundles—fine for local/dev; for production, proxy Gemini on the backend and add rate limits. Do not commit real keys; .env stays local only.