### PR TITLE
refactor(hooks): use matchMedia.matches consistently in useIsMobile

### DIFF
--- a/src/hooks/use-mobile.tsx
+++ b/src/hooks/use-mobile.tsx
@@ -2,18 +2,27 @@ import * as React from "react";
 
 const MOBILE_BREAKPOINT = 768;
 
-export function useIsMobile() {
+const mobileMediaQuery = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`;
+
+/**
+ * Subscribes to a single mobile breakpoint. Uses `matchMedia(...).matches` for
+ * both the initial read and change events so behavior stays aligned with the
+ * same CSS media query (viewport semantics, zoom, etc.).
+ */
+export function useIsMobile(): boolean {
   const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined);
 
   React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    const mql = window.matchMedia(mobileMediaQuery);
+
+    const sync = () => {
+      setIsMobile(mql.matches);
     };
-    mql.addEventListener("change", onChange);
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
-    return () => mql.removeEventListener("change", onChange);
+
+    sync();
+    mql.addEventListener("change", sync);
+    return () => mql.removeEventListener("change", sync);
   }, []);
 
-  return !!isMobile;
+  return Boolean(isMobile);
 }


### PR DESCRIPTION
Align initial sync and change handler with the same media query string for predictable responsive behavior and explicit boolean return type.

Made-with: Cursor