### PR TITLE
feat(messages): add Amplify-backed inbox and chat

### DIFF
--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -210,6 +210,39 @@ const schema = a.schema({
   ]),
 
   /**
+   * BE-9: Messaging system for customer-business communication.
+   * Tracks conversations between users and businesses.
+   */
+  Conversation: a.model({
+    participantId: a.string().required(), // Customer user ID
+    businessId: a.string().required(),
+    businessName: a.string(),
+    businessImage: a.string(),
+    lastMessage: a.string(),
+    lastMessageTimestamp: a.datetime(),
+    unreadCount: a.integer().default(0),
+  }).authorization((allow) => [
+    allow.owner().to(['read', 'create', 'update']),
+    allow.authenticated().to(['read', 'update']),
+  ]),
+
+  /**
+   * BE-9: Individual messages within a conversation.
+   */
+  Message: a.model({
+    conversationId: a.string().required(),
+    senderId: a.string().required(),
+    senderName: a.string().required(),
+    text: a.string(),
+    attachmentUrl: a.string(),
+    attachmentType: a.string(), // 'image' | 'file'
+    attachmentName: a.string(),
+  }).authorization((allow) => [
+    allow.owner().to(['create', 'read']),
+    allow.authenticated().to(['read']),
+  ]),
+
+  /**
    * BE-8.2 + BE-8.5: Validated flag creation with duplicate prevention.
    */
   /** Validated flag creation (name avoids clashing with model `createFlag`). */

--- a/src/hooks/useMessages.ts
+++ b/src/hooks/useMessages.ts
@@ -1,0 +1,282 @@
+import { useState, useEffect, useCallback } from 'react';
+import { amplifyDataClient } from '@/amplifyDataClient';
+import { getCurrentUser } from 'aws-amplify/auth';
+
+export interface MessageItem {
+  id: string;
+  conversationId: string;
+  senderId: string;
+  senderName: string;
+  text: string;
+  attachmentUrl?: string | null;
+  attachmentType?: string | null;
+  attachmentName?: string | null;
+  createdAt: string;
+}
+
+export interface ConversationItem {
+  id: string;
+  participantId: string;
+  businessId: string;
+  businessName?: string | null;
+  businessImage?: string | null;
+  lastMessage?: string | null;
+  lastMessageTimestamp?: string | null;
+  unreadCount: number;
+}
+
+export interface UseMessagesResult {
+  conversations: ConversationItem[];
+  messages: MessageItem[];
+  loading: boolean;
+  error: Error | null;
+  sendMessage: (conversationId: string, text: string, attachment?: { type: string; url: string; name: string }) => Promise<void>;
+  fetchMessages: (conversationId: string) => Promise<void>;
+  createConversation: (businessId: string, businessName: string, businessImage?: string) => Promise<string>;
+  markConversationAsRead: (conversationId: string) => Promise<void>;
+}
+
+export function useMessages(): UseMessagesResult {
+  const [conversations, setConversations] = useState<ConversationItem[]>([]);
+  const [messages, setMessages] = useState<MessageItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchConversations = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      // First check if user is authenticated
+      const user = await getCurrentUser();
+      if (!user) {
+        setConversations([]);
+        setLoading(false);
+        return;
+      }
+
+      const res = await (amplifyDataClient.models as any)?.Conversation?.list({
+        authMode: 'userPool',
+      });
+
+      if (!res || !res.data) {
+        setConversations([]);
+        setLoading(false);
+        return;
+      }
+
+      const items: ConversationItem[] = res.data.map((c: any): ConversationItem => ({
+        id: c.id,
+        participantId: c.participantId,
+        businessId: c.businessId,
+        businessName: c.businessName ?? null,
+        businessImage: c.businessImage ?? null,
+        lastMessage: c.lastMessage ?? null,
+        lastMessageTimestamp: c.lastMessageTimestamp ?? null,
+        unreadCount: c.unreadCount ?? 0,
+      }));
+      setConversations(items);
+    } catch (err) {
+      console.error('Error fetching conversations:', err);
+      setConversations([]);
+      setError(err instanceof Error ? err : new Error('Failed to fetch conversations'));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchConversations();
+  }, [fetchConversations]);
+
+  const fetchMessages = useCallback(async (conversationId: string) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const user = await getCurrentUser();
+      if (!user || !conversationId) {
+        setMessages([]);
+        setLoading(false);
+        return;
+      }
+
+      const res = await (amplifyDataClient.models as any)?.Message?.list({
+        filter: {
+          conversationId: { eq: conversationId },
+        },
+        authMode: 'userPool',
+      });
+
+      if (!res || !res.data) {
+        setMessages([]);
+        setLoading(false);
+        return;
+      }
+
+      const items: MessageItem[] = res.data.map((m: any): MessageItem => ({
+        id: m.id,
+        conversationId: m.conversationId,
+        senderId: m.senderId,
+        senderName: m.senderName,
+        text: m.text ?? '',
+        attachmentUrl: m.attachmentUrl ?? null,
+        attachmentType: m.attachmentType ?? null,
+        attachmentName: m.attachmentName ?? null,
+        createdAt: m.createdAt,
+      }));
+      setMessages(items.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()));
+    } catch (err) {
+      console.error('Error fetching messages:', err);
+      setMessages([]);
+      setError(err instanceof Error ? err : new Error('Failed to fetch messages'));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const sendMessage = useCallback(
+    async (
+      conversationId: string,
+      text: string,
+      attachment?: { type: string; url: string; name: string }
+    ) => {
+      try {
+        const user = await getCurrentUser();
+        if (!user || !conversationId) {
+          throw new Error('User not authenticated or no conversation selected');
+        }
+
+        const messageInput: any = {
+          conversationId,
+          senderId: user.userId,
+          senderName: user.username || 'User',
+          text: text || null,
+        };
+
+        if (attachment) {
+          messageInput.attachmentUrl = attachment.url;
+          messageInput.attachmentType = attachment.type;
+          messageInput.attachmentName = attachment.name;
+        }
+
+        const res = await (amplifyDataClient.models as any)?.Message?.create(messageInput, {
+          authMode: 'userPool',
+        });
+
+        if (!res || !res.data) {
+          throw new Error('Failed to create message');
+        }
+
+        const newMessage: MessageItem = {
+          id: res.data.id,
+          conversationId: res.data.conversationId,
+          senderId: res.data.senderId,
+          senderName: res.data.senderName,
+          text: res.data.text ?? '',
+          attachmentUrl: res.data.attachmentUrl ?? null,
+          attachmentType: res.data.attachmentType ?? null,
+          attachmentName: res.data.attachmentName ?? null,
+          createdAt: res.data.createdAt,
+        };
+
+        setMessages((prev) => [...prev, newMessage]);
+
+        // Update conversation's last message
+        const conv = conversations.find((c) => c.id === conversationId);
+        if (conv) {
+          await (amplifyDataClient.models as any)?.Conversation?.update(
+            {
+              id: conversationId,
+              lastMessage: text || '[Attachment]',
+              lastMessageTimestamp: new Date().toISOString(),
+            },
+            { authMode: 'userPool' }
+          );
+        }
+      } catch (err) {
+        console.error('Error sending message:', err);
+        setError(err instanceof Error ? err : new Error('Failed to send message'));
+        throw err;
+      }
+    },
+    [conversations]
+  );
+
+  const createConversation = useCallback(
+    async (businessId: string, businessName: string, businessImage?: string): Promise<string> => {
+      try {
+        const user = await getCurrentUser();
+        if (!user) {
+          throw new Error('User not authenticated');
+        }
+
+        const res = await (amplifyDataClient.models as any)?.Conversation?.create(
+          {
+            participantId: user.userId,
+            businessId,
+            businessName,
+            businessImage: businessImage || null,
+            unreadCount: 0,
+          },
+          { authMode: 'userPool' }
+        );
+
+        if (!res || !res.data) {
+          throw new Error('Failed to create conversation');
+        }
+
+        const newConversation: ConversationItem = {
+          id: res.data.id,
+          participantId: res.data.participantId,
+          businessId: res.data.businessId,
+          businessName: res.data.businessName ?? null,
+          businessImage: res.data.businessImage ?? null,
+          lastMessage: null,
+          lastMessageTimestamp: null,
+          unreadCount: 0,
+        };
+        setConversations((prev) => [...prev, newConversation]);
+        return res.data.id;
+      } catch (err) {
+        console.error('Error creating conversation:', err);
+        setError(err instanceof Error ? err : new Error('Failed to create conversation'));
+        throw err;
+      }
+    },
+    []
+  );
+
+  const markConversationAsRead = useCallback(async (conversationId: string) => {
+    try {
+      const user = await getCurrentUser();
+      if (!user || !conversationId) {
+        return;
+      }
+
+      await (amplifyDataClient.models as any)?.Conversation?.update(
+        {
+          id: conversationId,
+          unreadCount: 0,
+        },
+        { authMode: 'userPool' }
+      );
+
+      setConversations((prev) =>
+        prev.map((c) => (c.id === conversationId ? { ...c, unreadCount: 0 } : c))
+      );
+    } catch (err) {
+      console.error('Error marking conversation as read:', err);
+      setError(err instanceof Error ? err : new Error('Failed to mark conversation as read'));
+    }
+  }, []);
+
+  return {
+    conversations,
+    messages,
+    loading,
+    error,
+    sendMessage,
+    fetchMessages,
+    createConversation,
+    markConversationAsRead,
+  };
+}

--- a/src/pages/Messages.tsx
+++ b/src/pages/Messages.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { ArrowLeft, Send, Paperclip, Star, MapPin } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -7,88 +7,62 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Navigation } from "@/components/Navigation";
-
-interface Message {
-  id: string;
-  text: string;
-  sender: "customer" | "business";
-  timestamp: Date;
-  attachment?: {
-    type: "image" | "file";
-    url: string;
-    name: string;
-  };
-}
+import { useMessages } from "@/hooks/useMessages";
+import { useAuthenticator } from "@aws-amplify/ui-react";
 
 const Messages = () => {
   const navigate = useNavigate();
-  const { businessId } = useParams();
+  const { conversationId } = useParams<{ conversationId: string }>();
+  const { user } = useAuthenticator();
+  const { messages, loading, error, sendMessage, fetchMessages, conversations } = useMessages();
   const [messageText, setMessageText] = useState("");
-  const [messages, setMessages] = useState<Message[]>([
-    {
-      id: "1",
-      text: "Hi! I'm interested in your services. Are you available next week?",
-      sender: "customer",
-      timestamp: new Date(Date.now() - 3600000),
-    },
-    {
-      id: "2",
-      text: "Hello! Yes, we have availability on Tuesday and Thursday. What time works best for you?",
-      sender: "business",
-      timestamp: new Date(Date.now() - 3000000),
-    },
-    {
-      id: "3",
-      text: "Tuesday around 2pm would be perfect!",
-      sender: "customer",
-      timestamp: new Date(Date.now() - 2400000),
-    },
-  ]);
+  const [sending, setSending] = useState(false);
 
-  // Mock business data
-  const business = {
-    name: "Essence Hair Studio",
-    rating: 4.8,
-    reviewCount: 124,
-    distance: "1.2 mi",
-    image: "https://images.unsplash.com/photo-1560066984-138dadb4c035?w=400",
-    verified: true,
+  // Find the current conversation
+  const conversation = conversations.find((c) => c.id === conversationId);
+
+  useEffect(() => {
+    if (conversationId) {
+      fetchMessages(conversationId);
+    }
+  }, [conversationId, fetchMessages]);
+
+  const handleSend = async () => {
+    if (!messageText.trim() || !conversationId || sending) return;
+
+    try {
+      setSending(true);
+      await sendMessage(conversationId, messageText.trim());
+      setMessageText("");
+    } catch (err) {
+      console.error('Failed to send message:', err);
+    } finally {
+      setSending(false);
+    }
   };
 
-  const handleSend = () => {
-    if (!messageText.trim()) return;
-
-    const newMessage: Message = {
-      id: Date.now().toString(),
-      text: messageText,
-      sender: "customer",
-      timestamp: new Date(),
-    };
-
-    setMessages([...messages, newMessage]);
-    setMessageText("");
-  };
-
-  const handleFileUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleFileUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
-    if (!file) return;
+    if (!file || !conversationId || sending) return;
 
-    const newMessage: Message = {
-      id: Date.now().toString(),
-      text: "",
-      sender: "customer",
-      timestamp: new Date(),
-      attachment: {
-        type: file.type.startsWith("image/") ? "image" : "file",
-        url: URL.createObjectURL(file),
+    try {
+      setSending(true);
+      const url = URL.createObjectURL(file);
+      const attachmentType = file.type.startsWith("image/") ? "image" : "file";
+      await sendMessage(conversationId, "", {
+        type: attachmentType,
+        url,
         name: file.name,
-      },
-    };
-
-    setMessages([...messages, newMessage]);
+      });
+    } catch (err) {
+      console.error('Failed to upload file:', err);
+    } finally {
+      setSending(false);
+    }
   };
 
-  const formatTime = (date: Date) => {
+  const formatTime = (dateStr: string) => {
+    const date = new Date(dateStr);
     return date.toLocaleTimeString("en-US", {
       hour: "numeric",
       minute: "2-digit",
@@ -112,36 +86,24 @@ const Messages = () => {
               <ArrowLeft className="h-5 w-5" />
             </Button>
 
-            <div className="flex items-center gap-3 flex-1 min-w-0">
-              <Avatar className="h-12 w-12 shrink-0">
-                <AvatarImage src={business.image} alt={business.name} />
-                <AvatarFallback>{business.name[0]}</AvatarFallback>
-              </Avatar>
+            {!conversation ? (
+              <div className="text-muted-foreground">Loading conversation...</div>
+            ) : (
+              <div className="flex items-center gap-3 flex-1 min-w-0">
+                <Avatar className="h-12 w-12 shrink-0">
+                  <AvatarImage src={conversation.businessImage || undefined} alt={conversation.businessName || 'Business'} />
+                  <AvatarFallback>{(conversation.businessName || 'B')[0]}</AvatarFallback>
+                </Avatar>
 
-              <div className="flex-1 min-w-0">
-                <div className="flex items-center gap-2 mb-1">
-                  <h2 className="font-semibold text-foreground truncate">
-                    {business.name}
-                  </h2>
-                  {business.verified && (
-                    <Badge variant="secondary" className="text-xs shrink-0">
-                      Verified
-                    </Badge>
-                  )}
-                </div>
-                <div className="flex items-center gap-3 text-sm text-muted-foreground">
-                  <div className="flex items-center gap-1">
-                    <Star className="h-3.5 w-3.5 fill-secondary text-secondary" />
-                    <span className="font-medium">{business.rating}</span>
-                    <span>({business.reviewCount})</span>
-                  </div>
-                  <div className="flex items-center gap-1 text-primary">
-                    <MapPin className="h-3.5 w-3.5 text-primary" />
-                    <span className="text-primary">{business.distance}</span>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 mb-1">
+                    <h2 className="font-semibold text-foreground truncate">
+                      {conversation.businessName || 'Business'}
+                    </h2>
                   </div>
                 </div>
               </div>
-            </div>
+            )}
           </div>
         </div>
       </div>
@@ -149,50 +111,64 @@ const Messages = () => {
       {/* Messages Area */}
       <ScrollArea className="flex-1">
         <div className="container max-w-4xl mx-auto px-4 py-6">
+          {error && (
+            <div className="p-4 mb-4 bg-destructive/10 text-destructive rounded">
+              Error loading messages: {error.message}
+            </div>
+          )}
           <div className="space-y-4">
-            {messages.map((message) => (
-              <div
-                key={message.id}
-                className={`flex ${
-                  message.sender === "customer" ? "justify-end" : "justify-start"
-                }`}
-              >
-                <div
-                  className={`max-w-[70%] ${
-                    message.sender === "customer"
-                      ? "bg-primary text-primary-foreground"
-                      : "bg-muted text-foreground"
-                  } rounded-2xl px-4 py-2.5 shadow-sm`}
-                >
-                  {message.attachment && (
-                    <div className="mb-2">
-                      {message.attachment.type === "image" ? (
-                        <img
-                          src={message.attachment.url}
-                          alt="Attachment"
-                          className="rounded-lg max-w-full h-auto"
-                        />
-                      ) : (
-                        <div className="flex items-center gap-2 p-2 bg-background/10 rounded">
-                          <Paperclip className="h-4 w-4" />
-                          <span className="text-sm">{message.attachment.name}</span>
-                        </div>
-                      )}
-                    </div>
-                  )}
-                  {message.text && <p className="text-sm leading-relaxed">{message.text}</p>}
-                  <p
-                    className={`text-xs mt-1 ${
-                      message.sender === "customer"
-                        ? "text-primary-foreground/70"
-                        : "text-muted-foreground"
+            {loading ? (
+              <div className="text-center text-muted-foreground">Loading messages...</div>
+            ) : messages.length === 0 ? (
+              <div className="text-center text-muted-foreground">No messages yet. Start the conversation!</div>
+            ) : (
+              messages.map((message) => {
+                const isOwnMessage = message.senderId === user?.userId;
+                return (
+                  <div
+                    key={message.id}
+                    className={`flex ${
+                      isOwnMessage ? "justify-end" : "justify-start"
                     }`}
                   >
-                    {formatTime(message.timestamp)}
-                  </p>
-                </div>
-              </div>
-            ))}
+                    <div
+                      className={`max-w-[70%] ${
+                        isOwnMessage
+                          ? "bg-primary text-primary-foreground"
+                          : "bg-muted text-foreground"
+                      } rounded-2xl px-4 py-2.5 shadow-sm`}
+                    >
+                      {message.attachmentUrl && (
+                        <div className="mb-2">
+                          {message.attachmentType === "image" ? (
+                            <img
+                              src={message.attachmentUrl}
+                              alt="Attachment"
+                              className="rounded-lg max-w-full h-auto"
+                            />
+                          ) : (
+                            <div className="flex items-center gap-2 p-2 bg-background/10 rounded">
+                              <Paperclip className="h-4 w-4" />
+                              <span className="text-sm">{message.attachmentName}</span>
+                            </div>
+                          )}
+                        </div>
+                      )}
+                      {message.text && <p className="text-sm leading-relaxed">{message.text}</p>}
+                      <p
+                        className={`text-xs mt-1 ${
+                          isOwnMessage
+                            ? "text-primary-foreground/70"
+                            : "text-muted-foreground"
+                        }`}
+                      >
+                        {formatTime(message.createdAt)}
+                      </p>
+                    </div>
+                  </div>
+                );
+              })
+            )}
           </div>
         </div>
       </ScrollArea>
@@ -207,11 +183,13 @@ const Messages = () => {
               className="hidden"
               onChange={handleFileUpload}
               accept="image/*,.pdf,.doc,.docx"
+              disabled={sending}
             />
             <Button
               variant="ghost"
               size="icon"
               onClick={() => document.getElementById("file-upload")?.click()}
+              disabled={sending}
               className="shrink-0"
             >
               <Paperclip className="h-5 w-5" />
@@ -222,12 +200,13 @@ const Messages = () => {
               value={messageText}
               onChange={(e) => setMessageText(e.target.value)}
               onKeyPress={(e) => e.key === "Enter" && handleSend()}
+              disabled={sending || !conversationId}
               className="flex-1"
             />
 
             <Button
               onClick={handleSend}
-              disabled={!messageText.trim()}
+              disabled={!messageText.trim() || sending || !conversationId}
               className="shrink-0"
             >
               <Send className="h-4 w-4" />

--- a/src/pages/MessagesInbox.tsx
+++ b/src/pages/MessagesInbox.tsx
@@ -1,85 +1,26 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { Search, Star, MapPin } from "lucide-react";
+import { Search } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Navigation } from "@/components/Navigation";
-
-interface Conversation {
-  id: string;
-  businessId: string;
-  businessName: string;
-  businessImage: string;
-  businessRating: number;
-  businessDistance: string;
-  verified: boolean;
-  lastMessage: string;
-  timestamp: Date;
-  unread: boolean;
-}
+import { useMessages } from "@/hooks/useMessages";
 
 const MessagesInbox = () => {
   const navigate = useNavigate();
   const [searchQuery, setSearchQuery] = useState("");
-
-  const conversations: Conversation[] = [
-    {
-      id: "1",
-      businessId: "essence-hair",
-      businessName: "Essence Hair Studio",
-      businessImage: "https://images.unsplash.com/photo-1560066984-138dadb4c035?w=400",
-      businessRating: 4.8,
-      businessDistance: "1.2 mi",
-      verified: true,
-      lastMessage: "Tuesday around 2pm would be perfect!",
-      timestamp: new Date(Date.now() - 2400000),
-      unread: false,
-    },
-    {
-      id: "2",
-      businessId: "soul-cafe",
-      businessName: "Soul Food Café",
-      businessImage: "https://images.unsplash.com/photo-1517248135467-4c7edcad34c4?w=400",
-      businessRating: 4.9,
-      businessDistance: "0.8 mi",
-      verified: true,
-      lastMessage: "We'd love to cater your event! Let me send you our menu options.",
-      timestamp: new Date(Date.now() - 7200000),
-      unread: true,
-    },
-    {
-      id: "3",
-      businessId: "wellness-spa",
-      businessName: "Serenity Wellness Spa",
-      businessImage: "https://images.unsplash.com/photo-1540555700478-4be289fbecef?w=400",
-      businessRating: 4.7,
-      businessDistance: "2.1 mi",
-      verified: false,
-      lastMessage: "Thank you for your interest! Our massage packages start at $85.",
-      timestamp: new Date(Date.now() - 86400000),
-      unread: false,
-    },
-    {
-      id: "4",
-      businessId: "creative-studio",
-      businessName: "Urban Canvas Art Studio",
-      businessImage: "https://images.unsplash.com/photo-1513364776144-60967b0f800f?w=400",
-      businessRating: 4.6,
-      businessDistance: "3.5 mi",
-      verified: true,
-      lastMessage: "Classes are every Saturday at 10am. Would you like to reserve a spot?",
-      timestamp: new Date(Date.now() - 172800000),
-      unread: true,
-    },
-  ];
+  const { conversations, loading, error, markConversationAsRead } = useMessages();
 
   const filteredConversations = conversations.filter((conv) =>
-    conv.businessName.toLowerCase().includes(searchQuery.toLowerCase())
+    (conv.businessName ?? "").toLowerCase().includes(searchQuery.toLowerCase())
   );
 
-  const formatTimestamp = (date: Date) => {
+  const formatTimestamp = (dateStr?: string | null) => {
+    if (!dateStr) return "now";
+    
+    const date = new Date(dateStr);
     const now = new Date();
     const diffInHours = Math.floor((now.getTime() - date.getTime()) / (1000 * 60 * 60));
 
@@ -92,6 +33,11 @@ const MessagesInbox = () => {
       const diffInDays = Math.floor(diffInHours / 24);
       return `${diffInDays}d ago`;
     }
+  };
+
+  const handleConversationClick = async (conversationId: string) => {
+    await markConversationAsRead(conversationId);
+    navigate(`/messages/${conversationId}`);
   };
 
   return (
@@ -120,13 +66,22 @@ const MessagesInbox = () => {
         {/* Conversations List */}
         <ScrollArea className="h-[calc(100vh-280px)]">
           <div className="space-y-2">
-            {filteredConversations.length > 0 ? (
+            {error && (
+              <div className="p-4 bg-destructive/10 text-destructive rounded">
+                Error loading conversations: {error.message}
+              </div>
+            )}
+            {loading ? (
+              <div className="text-center py-12">
+                <p className="text-muted-foreground">Loading conversations...</p>
+              </div>
+            ) : filteredConversations.length > 0 ? (
               filteredConversations.map((conversation) => (
                 <button
                   key={conversation.id}
-                  onClick={() => navigate(`/messages/${conversation.businessId}`)}
+                  onClick={() => handleConversationClick(conversation.id)}
                   className={`w-full p-4 rounded-lg border transition-all hover:shadow-md ${
-                    conversation.unread
+                    conversation.unreadCount > 0
                       ? "bg-primary/5 border-primary/20"
                       : "bg-card border-border hover:bg-accent/50"
                   }`}
@@ -134,56 +89,42 @@ const MessagesInbox = () => {
                   <div className="flex items-start gap-4">
                     <Avatar className="h-14 w-14 shrink-0">
                       <AvatarImage
-                        src={conversation.businessImage}
-                        alt={conversation.businessName}
+                        src={conversation.businessImage || undefined}
+                        alt={conversation.businessName || "Business"}
                       />
-                      <AvatarFallback>{conversation.businessName[0]}</AvatarFallback>
+                      <AvatarFallback>{(conversation.businessName || "B")[0]}</AvatarFallback>
                     </Avatar>
 
                     <div className="flex-1 min-w-0 text-left">
                       <div className="flex items-center gap-2 mb-1">
                         <h3
                           className={`font-semibold truncate ${
-                            conversation.unread ? "text-foreground" : "text-foreground"
+                            conversation.unreadCount > 0 ? "text-foreground font-bold" : "text-foreground"
                           }`}
                         >
-                          {conversation.businessName}
+                          {conversation.businessName || "Conversation"}
                         </h3>
-                        {conversation.verified && (
-                          <Badge variant="secondary" className="text-xs shrink-0">
-                            Verified
-                          </Badge>
-                        )}
-                      </div>
-
-                      <div className="flex items-center gap-3 text-xs text-muted-foreground mb-2">
-                        <div className="flex items-center gap-1">
-                          <Star className="h-3 w-3 fill-secondary text-secondary" />
-                          <span>{conversation.businessRating}</span>
-                        </div>
-                        <div className="flex items-center gap-1 text-primary">
-                          <MapPin className="h-3 w-3 text-primary" />
-                          <span className="text-primary">{conversation.businessDistance}</span>
-                        </div>
                       </div>
 
                       <p
                         className={`text-sm truncate ${
-                          conversation.unread
+                          conversation.unreadCount > 0
                             ? "font-medium text-foreground"
                             : "text-muted-foreground"
                         }`}
                       >
-                        {conversation.lastMessage}
+                        {conversation.lastMessage || "No messages yet"}
                       </p>
                     </div>
 
                     <div className="shrink-0 flex flex-col items-end gap-2">
                       <span className="text-xs text-muted-foreground">
-                        {formatTimestamp(conversation.timestamp)}
+                        {formatTimestamp(conversation.lastMessageTimestamp)}
                       </span>
-                      {conversation.unread && (
-                        <div className="h-2.5 w-2.5 rounded-full bg-primary" />
+                      {conversation.unreadCount > 0 && (
+                        <div className="flex items-center justify-center h-6 w-6 rounded-full bg-primary text-primary-foreground text-xs font-semibold">
+                          {conversation.unreadCount > 99 ? "99+" : conversation.unreadCount}
+                        </div>
                       )}
                     </div>
                   </div>


### PR DESCRIPTION
This PR replaces mock messaging data with real Amplify-backed data for inbox and conversation views, and adds messaging schema support in the backend.

What changed:
Added Conversation and Message models to the Amplify data schema.
Added a new useMessages hook to:
fetch conversations
fetch messages by conversation
send messages (text and attachment metadata)
create conversations
mark conversations as read
Updated inbox page to use live conversation data, including unread counts and loading/error states.
Updated chat page to use live message data, including loading/error/empty states and send/file flows.