### PR TITLE
Chore/db test handoff 20260413 135807

### DIFF
--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -215,12 +215,18 @@ const schema = a.schema({
    */
   Conversation: a.model({
     participantId: a.string().required(), // Customer user ID
+    /** Denormalized customer display for business-side inbox/thread headers. */
+    participantName: a.string(),
+    participantAvatarUrl: a.string(),
     businessId: a.string().required(),
     businessName: a.string(),
     businessImage: a.string(),
     lastMessage: a.string(),
     lastMessageTimestamp: a.datetime(),
+    /** Unread messages for the customer (`participantId`) when the business has sent. */
     unreadCount: a.integer().default(0),
+    /** Unread messages for the business owner when the customer has sent. */
+    businessUnreadCount: a.integer().default(0),
     /** Customer hides thread on their side only; business-facing views unaffected. */
     participantHidden: a.boolean().default(false),
     /** When true, alerts/toasts for new activity on this thread are suppressed for the participant. */

--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -221,6 +221,10 @@ const schema = a.schema({
     lastMessage: a.string(),
     lastMessageTimestamp: a.datetime(),
     unreadCount: a.integer().default(0),
+    /** Customer hides thread on their side only; business-facing views unaffected. */
+    participantHidden: a.boolean().default(false),
+    /** When true, alerts/toasts for new activity on this thread are suppressed for the participant. */
+    participantMuted: a.boolean().default(false),
   }).authorization((allow) => [
     allow.owner().to(['read', 'create', 'update']),
     allow.authenticated().to(['read', 'update']),

--- a/amplify_outputs.json
+++ b/amplify_outputs.json
@@ -967,6 +967,37 @@
       },
       "enums": {},
       "nonModels": {
+        "AssistantChatReply": {
+          "name": "AssistantChatReply",
+          "fields": {
+            "reply": {
+              "name": "reply",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            }
+          }
+        },
+        "ChatAssistantTurn": {
+          "name": "ChatAssistantTurn",
+          "fields": {
+            "role": {
+              "name": "role",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "content": {
+              "name": "content",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            }
+          }
+        },
         "FlagTargetDetails": {
           "name": "FlagTargetDetails",
           "fields": {
@@ -1385,6 +1416,31 @@
         }
       },
       "mutations": {
+        "chatWithAssistant": {
+          "name": "chatWithAssistant",
+          "isArray": false,
+          "type": {
+            "nonModel": "AssistantChatReply"
+          },
+          "isRequired": false,
+          "arguments": {
+            "message": {
+              "name": "message",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true
+            },
+            "history": {
+              "name": "history",
+              "isArray": true,
+              "type": {
+                "input": "ChatAssistantTurn"
+              },
+              "isRequired": false,
+              "isArrayNullable": true
+            }
+          }
+        },
         "submitModerationFlag": {
           "name": "submitModerationFlag",
           "isArray": false,

--- a/amplify_outputs.json
+++ b/amplify_outputs.json
@@ -1023,6 +1023,20 @@
               "isRequired": false,
               "attributes": []
             },
+            "participantHidden": {
+              "name": "participantHidden",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": false,
+              "attributes": []
+            },
+            "participantMuted": {
+              "name": "participantMuted",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": false,
+              "attributes": []
+            },
             "createdAt": {
               "name": "createdAt",
               "isArray": false,

--- a/amplify_outputs.json
+++ b/amplify_outputs.json
@@ -963,41 +963,238 @@
             "primaryKeyFieldName": "id",
             "sortKeyFieldNames": []
           }
-        }
-      },
-      "enums": {},
-      "nonModels": {
-        "AssistantChatReply": {
-          "name": "AssistantChatReply",
+        },
+        "Conversation": {
+          "name": "Conversation",
           "fields": {
-            "reply": {
-              "name": "reply",
+            "id": {
+              "name": "id",
               "isArray": false,
-              "type": "String",
+              "type": "ID",
               "isRequired": true,
               "attributes": []
-            }
-          }
-        },
-        "ChatAssistantTurn": {
-          "name": "ChatAssistantTurn",
-          "fields": {
-            "role": {
-              "name": "role",
+            },
+            "participantId": {
+              "name": "participantId",
               "isArray": false,
               "type": "String",
               "isRequired": true,
               "attributes": []
             },
-            "content": {
-              "name": "content",
+            "businessId": {
+              "name": "businessId",
               "isArray": false,
               "type": "String",
               "isRequired": true,
               "attributes": []
+            },
+            "businessName": {
+              "name": "businessName",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "businessImage": {
+              "name": "businessImage",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "lastMessage": {
+              "name": "lastMessage",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "lastMessageTimestamp": {
+              "name": "lastMessageTimestamp",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": []
+            },
+            "unreadCount": {
+              "name": "unreadCount",
+              "isArray": false,
+              "type": "Int",
+              "isRequired": false,
+              "attributes": []
+            },
+            "createdAt": {
+              "name": "createdAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            },
+            "updatedAt": {
+              "name": "updatedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
             }
+          },
+          "syncable": true,
+          "pluralName": "Conversations",
+          "attributes": [
+            {
+              "type": "model",
+              "properties": {}
+            },
+            {
+              "type": "auth",
+              "properties": {
+                "rules": [
+                  {
+                    "provider": "userPools",
+                    "ownerField": "owner",
+                    "allow": "owner",
+                    "operations": [
+                      "read",
+                      "create",
+                      "update"
+                    ],
+                    "identityClaim": "cognito:username"
+                  },
+                  {
+                    "allow": "private",
+                    "operations": [
+                      "read",
+                      "update"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "primaryKeyInfo": {
+            "isCustomPrimaryKey": false,
+            "primaryKeyFieldName": "id",
+            "sortKeyFieldNames": []
           }
         },
+        "Message": {
+          "name": "Message",
+          "fields": {
+            "id": {
+              "name": "id",
+              "isArray": false,
+              "type": "ID",
+              "isRequired": true,
+              "attributes": []
+            },
+            "conversationId": {
+              "name": "conversationId",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "senderId": {
+              "name": "senderId",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "senderName": {
+              "name": "senderName",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "text": {
+              "name": "text",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "attachmentUrl": {
+              "name": "attachmentUrl",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "attachmentType": {
+              "name": "attachmentType",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "attachmentName": {
+              "name": "attachmentName",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "createdAt": {
+              "name": "createdAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            },
+            "updatedAt": {
+              "name": "updatedAt",
+              "isArray": false,
+              "type": "AWSDateTime",
+              "isRequired": false,
+              "attributes": [],
+              "isReadOnly": true
+            }
+          },
+          "syncable": true,
+          "pluralName": "Messages",
+          "attributes": [
+            {
+              "type": "model",
+              "properties": {}
+            },
+            {
+              "type": "auth",
+              "properties": {
+                "rules": [
+                  {
+                    "provider": "userPools",
+                    "ownerField": "owner",
+                    "allow": "owner",
+                    "operations": [
+                      "create",
+                      "read"
+                    ],
+                    "identityClaim": "cognito:username"
+                  },
+                  {
+                    "allow": "private",
+                    "operations": [
+                      "read"
+                    ]
+                  }
+                ]
+              }
+            }
+          ],
+          "primaryKeyInfo": {
+            "isCustomPrimaryKey": false,
+            "primaryKeyFieldName": "id",
+            "sortKeyFieldNames": []
+          }
+        }
+      },
+      "enums": {},
+      "nonModels": {
         "FlagTargetDetails": {
           "name": "FlagTargetDetails",
           "fields": {
@@ -1416,31 +1613,6 @@
         }
       },
       "mutations": {
-        "chatWithAssistant": {
-          "name": "chatWithAssistant",
-          "isArray": false,
-          "type": {
-            "nonModel": "AssistantChatReply"
-          },
-          "isRequired": false,
-          "arguments": {
-            "message": {
-              "name": "message",
-              "isArray": false,
-              "type": "String",
-              "isRequired": true
-            },
-            "history": {
-              "name": "history",
-              "isArray": true,
-              "type": {
-                "input": "ChatAssistantTurn"
-              },
-              "isRequired": false,
-              "isArrayNullable": true
-            }
-          }
-        },
         "submitModerationFlag": {
           "name": "submitModerationFlag",
           "isArray": false,

--- a/amplify_outputs.json
+++ b/amplify_outputs.json
@@ -981,6 +981,20 @@
               "isRequired": true,
               "attributes": []
             },
+            "participantName": {
+              "name": "participantName",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "participantAvatarUrl": {
+              "name": "participantAvatarUrl",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
             "businessId": {
               "name": "businessId",
               "isArray": false,
@@ -1018,6 +1032,13 @@
             },
             "unreadCount": {
               "name": "unreadCount",
+              "isArray": false,
+              "type": "Int",
+              "isRequired": false,
+              "attributes": []
+            },
+            "businessUnreadCount": {
+              "name": "businessUnreadCount",
               "isArray": false,
               "type": "Int",
               "isRequired": false,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,7 +35,7 @@ const App = () => (
             <Route path="/auth/forgot-password" element={<ForgotPassword />} />
             <Route path="/favorites" element={<Navigate to="/profile/favorites" replace />} />
           <Route path="/messages" element={<MessagesInbox />} />
-          <Route path="/messages/:businessId" element={<Messages />} />
+          <Route path="/messages/:conversationId" element={<Messages />} />
           <Route path="/register" element={<Navigate to="/register/1" replace />} />
           <Route path="/register/:step" element={<RegisterBusiness />} />
           <Route path="/business/:id" element={<BusinessProfilePage />} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,6 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { FaviconSync } from "@/components/FaviconSync";
 import { AuthProvider } from "@/contexts/AuthContext";
-import { RequireRole } from "@/components/auth";
 import Index from "./pages/Index";
 import Search from "./pages/Search";
 import Auth from "./pages/Auth";
@@ -17,6 +16,7 @@ import BusinessProfilePage from "./pages/BusinessProfile";
 import NotFound from "./pages/NotFound";
 import Profile from "./pages/Profile";
 import { UpliftChatAssistant } from "@/components/chat/UpliftChatAssistant";
+import { MessageNotificationListener } from "@/components/messaging/MessageNotificationListener";
 
 const queryClient = new QueryClient();
 
@@ -26,8 +26,9 @@ const App = () => (
       <TooltipProvider>
       <Toaster />
       <Sonner />
-      <BrowserRouter>
+        <BrowserRouter>
         <FaviconSync />
+        <MessageNotificationListener />
         <Routes>
           <Route path="/" element={<Index />} />
           <Route path="/search" element={<Search />} />

--- a/src/components/business-profile/BusinessProfileLayout.tsx
+++ b/src/components/business-profile/BusinessProfileLayout.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/components/ui/breadcrumb";
 import { Button } from "@/components/ui/button";
 import { Container } from "@/components/shared";
-import { ChevronLeft } from "lucide-react";
+import { ChevronLeft, MessageCircle } from "lucide-react";
 import { BusinessHeader } from "./BusinessHeader";
 import { BusinessContactCard } from "./BusinessContactCard";
 import { BusinessGallery } from "./BusinessGallery";
@@ -28,6 +28,9 @@ export interface BusinessProfileLayoutProps extends React.HTMLAttributes<HTMLDiv
   /** Called when a user submits a review */
   onSubmitReview?: (params: { businessId: string; rating: number; text: string; authorName: string }) => Promise<void>;
   submittingReview?: boolean;
+  /** Optional action to start/open a message conversation for this business. */
+  onMessageBusiness?: () => void;
+  messagingInProgress?: boolean;
   /** Back link href (e.g. /search). If not set, breadcrumb still shows Search > Business name */
   backHref?: string;
 }
@@ -43,6 +46,8 @@ const BusinessProfileLayoutComponent = ({
   reviewCount = 0,
   onSubmitReview,
   submittingReview = false,
+  onMessageBusiness,
+  messagingInProgress = false,
   backHref = "/search",
   className,
   ...props
@@ -142,6 +147,17 @@ const BusinessProfileLayoutComponent = ({
           )}
         </div>
         <div>
+          {onMessageBusiness && (
+            <Button
+              type="button"
+              className="mb-4 w-full"
+              onClick={onMessageBusiness}
+              disabled={messagingInProgress}
+            >
+              <MessageCircle className="h-4 w-4" />
+              Message business
+            </Button>
+          )}
           <BusinessContactCard email={email} phone={phone} website={website} street={street} city={city} state={state} zip={zip} />
         </div>
       </div>

--- a/src/components/business-profile/ReviewForm.tsx
+++ b/src/components/business-profile/ReviewForm.tsx
@@ -10,20 +10,12 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useAuth } from "@/contexts/AuthContext";
 import { useToast } from "@/hooks/use-toast";
 import { cn } from "@/lib/utils";
+import { formatDisplayNameForReviews } from "@/lib/format-display-name";
 
 export interface ReviewFormProps {
   businessId: string;
   submitting?: boolean;
   onSubmit: (params: { businessId: string; rating: number; text: string; authorName: string }) => Promise<void>;
-}
-
-/** Format "Hannah Gollner" → "Hannah G." */
-function formatDisplayName(fullName: string | undefined): string {
-  if (!fullName) return '';
-  const parts = fullName.trim().split(/\s+/);
-  const first = parts[0] ?? '';
-  const lastInitial = parts.length > 1 ? ` ${parts[parts.length - 1][0].toUpperCase()}.` : '';
-  return `${first}${lastInitial}`;
 }
 
 /**
@@ -44,7 +36,7 @@ export function ReviewForm({ businessId, submitting = false, onSubmit }: ReviewF
   React.useEffect(() => {
     if (!user) return;
     fetchUserAttributes()
-      .then((attrs) => setFormattedName(formatDisplayName(attrs.name)))
+      .then((attrs) => setFormattedName(formatDisplayNameForReviews(attrs.name)))
       .catch(() => setFormattedName(''));
   }, [user]);
 

--- a/src/components/chat/UpliftChatAssistant.tsx
+++ b/src/components/chat/UpliftChatAssistant.tsx
@@ -7,7 +7,12 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { cn } from "@/lib/utils";
-import { createUpliftChatSession, isGeminiConfigured, sendUpliftMessage } from "@/lib/gemini-chat";
+import {
+  createUpliftChatSession,
+  getUpliftFallbackReply,
+  isGeminiConfigured,
+  sendUpliftMessage,
+} from "@/lib/gemini-chat";
 
 type UiMessage = { role: "user" | "assistant"; text: string };
 
@@ -39,21 +44,22 @@ export function UpliftChatAssistant() {
     async (raw: string) => {
       const text = raw.trim();
       if (!text || sending) return;
-      if (!configured) {
-        toast.error("Add VITE_GEMINI_API_KEY to your .env file to enable the assistant.");
-        return;
-      }
 
       setMessages((prev) => [...prev, { role: "user", text }]);
       setInput("");
       setSending(true);
 
       try {
-        if (!chatRef.current) {
-          chatRef.current = createUpliftChatSession();
+        if (configured) {
+          if (!chatRef.current) {
+            chatRef.current = createUpliftChatSession();
+          }
+          const reply = await sendUpliftMessage(chatRef.current, text);
+          setMessages((prev) => [...prev, { role: "assistant", text: reply }]);
+        } else {
+          const reply = getUpliftFallbackReply(text);
+          setMessages((prev) => [...prev, { role: "assistant", text: reply }]);
         }
-        const reply = await sendUpliftMessage(chatRef.current, text);
-        setMessages((prev) => [...prev, { role: "assistant", text: reply }]);
       } catch (e) {
         const msg = e instanceof Error ? e.message : "Something went wrong.";
         toast.error("Assistant could not reply", { description: msg });
@@ -130,10 +136,9 @@ export function UpliftChatAssistant() {
 
           {!configured && (
             <p className="border-b border-border bg-muted/50 px-4 py-3 text-xs text-muted-foreground">
-              Set <code className="rounded bg-muted px-1 py-0.5 font-mono text-[11px]">VITE_GEMINI_API_KEY</code> in{" "}
+              Running in local help mode. Set <code className="rounded bg-muted px-1 py-0.5 font-mono text-[11px]">VITE_GEMINI_API_KEY</code> in{" "}
               <code className="rounded bg-muted px-1 py-0.5 font-mono text-[11px]">.env</code> and restart{" "}
-              <code className="rounded bg-muted px-1 py-0.5 font-mono text-[11px]">npm run dev</code>. Use a backend
-              proxy before shipping to production.
+              <code className="rounded bg-muted px-1 py-0.5 font-mono text-[11px]">npm run dev</code> for Gemini responses.
             </p>
           )}
 
@@ -169,7 +174,7 @@ export function UpliftChatAssistant() {
                   <button
                     key={label}
                     type="button"
-                    disabled={sending || !configured}
+                    disabled={sending}
                     onClick={() => void sendText(label)}
                     className={cn(
                       "rounded-full border border-primary/40 bg-primary/5 px-3 py-1.5 text-left text-xs font-medium text-foreground",
@@ -187,14 +192,14 @@ export function UpliftChatAssistant() {
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
                 placeholder="Ask about Uplift…"
-                disabled={sending || !configured}
+                disabled={sending}
                 className="min-w-0 flex-1 rounded-full border-border bg-muted/80"
                 aria-label="Message to assistant"
               />
               <Button
                 type="submit"
                 size="icon"
-                disabled={sending || !input.trim() || !configured}
+                disabled={sending || !input.trim()}
                 className="h-10 w-10 shrink-0 rounded-xl bg-primary text-primary-foreground hover:bg-primary-hover"
                 aria-label="Send message"
               >

--- a/src/components/messaging/ConversationChatMenu.tsx
+++ b/src/components/messaging/ConversationChatMenu.tsx
@@ -1,0 +1,64 @@
+import { MoreVertical, Bell, BellOff, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+type Props = {
+  /** When false, the trigger is not rendered (e.g. draft thread). */
+  openable: boolean;
+  participantMuted: boolean;
+  onToggleMute: () => void | Promise<void>;
+  onRequestDelete: () => void;
+  muteBusy?: boolean;
+};
+
+export function ConversationChatMenu({
+  openable,
+  participantMuted,
+  onToggleMute,
+  onRequestDelete,
+  muteBusy,
+}: Props) {
+  if (!openable) return null;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="shrink-0 text-muted-foreground"
+          aria-label="Chat options"
+        >
+          <MoreVertical className="h-5 w-5" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-52">
+        <DropdownMenuItem disabled={muteBusy} onSelect={() => void Promise.resolve(onToggleMute())}>
+          {participantMuted ? (
+            <>
+              <Bell className="mr-2 h-4 w-4" />
+              Unmute conversation
+            </>
+          ) : (
+            <>
+              <BellOff className="mr-2 h-4 w-4" />
+              Mute conversation
+            </>
+          )}
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem className="text-destructive focus:text-destructive" onSelect={onRequestDelete}>
+          <Trash2 className="mr-2 h-4 w-4" />
+          Delete…
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/components/messaging/DeleteConversationForMeDialog.tsx
+++ b/src/components/messaging/DeleteConversationForMeDialog.tsx
@@ -1,0 +1,52 @@
+import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+type Props = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void | Promise<void>;
+  pending?: boolean;
+};
+
+/**
+ * Confirms removing a conversation from the signed-in customer’s inbox only.
+ */
+export function DeleteConversationForMeDialog({ open, onOpenChange, onConfirm, pending }: Props) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Remove from your inbox?</AlertDialogTitle>
+          <AlertDialogDescription className="text-left">
+            This action only deletes the conversation for you. Others will still be able to see your messages.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={pending}>Cancel</AlertDialogCancel>
+          <Button
+            variant="destructive"
+            disabled={pending}
+            onClick={async () => {
+              try {
+                await onConfirm();
+                onOpenChange(false);
+              } catch {
+                // Parent handles toast; keep dialog open.
+              }
+            }}
+          >
+            {pending ? "Removing…" : "Remove"}
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/messaging/MessageNotificationListener.tsx
+++ b/src/components/messaging/MessageNotificationListener.tsx
@@ -3,6 +3,8 @@ import { useLocation } from "react-router-dom";
 import { getCurrentUser } from "aws-amplify/auth";
 import { amplifyDataClient } from "@/amplifyDataClient";
 import { useAuth } from "@/contexts/AuthContext";
+import { useOwnerBusiness } from "@/hooks/useOwnerBusiness";
+import { getViewerUnreadCount } from "@/lib/messaging-counterparty";
 import { toast } from "sonner";
 import { UPLIFT_REFRESH_CONVERSATIONS_EVENT } from "@/lib/messaging-events";
 
@@ -11,9 +13,13 @@ const MAX_TOASTS_PER_TICK = 2;
 
 type ConvRow = {
   id: string;
+  participantId?: string | null;
+  businessId?: string | null;
+  participantName?: string | null;
   lastMessage?: string | null;
   lastMessageTimestamp?: string | null;
   unreadCount?: number | null;
+  businessUnreadCount?: number | null;
   participantMuted?: boolean | null;
   participantHidden?: boolean | null;
   businessName?: string | null;
@@ -32,7 +38,9 @@ function getConversationModel() {
  * when a thread updates while the user is not actively viewing that chat.
  */
 export function MessageNotificationListener() {
-  const { user } = useAuth();
+  const { user, isBusiness } = useAuth();
+  const { backendRow } = useOwnerBusiness();
+  const ownBusinessId = backendRow?.id ?? null;
   const location = useLocation();
   const pathRef = useRef(location.pathname);
   pathRef.current = location.pathname;
@@ -44,13 +52,23 @@ export function MessageNotificationListener() {
     let snap: Snapshot | null = null;
     let timer: ReturnType<typeof setInterval> | undefined;
 
-    const toSnapshot = (rows: ConvRow[]): Snapshot => {
+    const toSnapshot = (rows: ConvRow[], me: string): Snapshot => {
       const s: Snapshot = {};
       for (const row of rows) {
         s[row.id] = {
           lm: row.lastMessage ?? null,
           ts: row.lastMessageTimestamp ?? null,
-          unread: row.unreadCount ?? 0,
+          unread: getViewerUnreadCount(
+            {
+              participantId: row.participantId ?? "",
+              businessId: row.businessId ?? "",
+              businessName: row.businessName,
+              participantName: row.participantName,
+              unreadCount: row.unreadCount,
+              businessUnreadCount: row.businessUnreadCount,
+            },
+            { userId: me, isBusiness, ownBusinessId }
+          ),
         };
       }
       return s;
@@ -58,8 +76,10 @@ export function MessageNotificationListener() {
 
     const tick = async () => {
       if (cancelled) return;
+      let me: string;
       try {
-        await getCurrentUser();
+        const u = await getCurrentUser();
+        me = u.userId;
       } catch {
         snap = null;
         return;
@@ -70,7 +90,7 @@ export function MessageNotificationListener() {
 
       const res = await model.list({ authMode: "userPool" });
       const rows = (res?.data ?? []).filter((c) => !c.participantHidden);
-      const nextSnap = toSnapshot(rows);
+      const nextSnap = toSnapshot(rows, me);
 
       const prev = snap;
       if (prev) {
@@ -94,10 +114,21 @@ export function MessageNotificationListener() {
 
           const p = prev[row.id];
           if (!p) continue;
+          const rowUnread = getViewerUnreadCount(
+            {
+              participantId: row.participantId ?? "",
+              businessId: row.businessId ?? "",
+              businessName: row.businessName,
+              participantName: row.participantName,
+              unreadCount: row.unreadCount,
+              businessUnreadCount: row.businessUnreadCount,
+            },
+            { userId: me, isBusiness, ownBusinessId }
+          );
           const changed =
             p.lm !== (row.lastMessage ?? null) ||
             p.ts !== (row.lastMessageTimestamp ?? null) ||
-            p.unread !== (row.unreadCount ?? 0);
+            p.unread !== rowUnread;
           if (!changed) continue;
           anyChange = true;
 
@@ -108,7 +139,11 @@ export function MessageNotificationListener() {
 
           if (shown >= MAX_TOASTS_PER_TICK) continue;
           shown += 1;
-          const title = row.businessName || "New message";
+          const participantId = row.participantId ?? "";
+          const title =
+            me === participantId
+              ? row.businessName || "New message"
+              : row.participantName?.trim() || row.businessName || "New message";
           const body =
             (row.lastMessage && String(row.lastMessage).slice(0, 140)) || "You have a new message";
           toast.info(title, { description: body, duration: 6500 });
@@ -138,7 +173,7 @@ export function MessageNotificationListener() {
       cancelled = true;
       if (timer) clearInterval(timer);
     };
-  }, [user?.userId]);
+  }, [user?.userId, isBusiness, ownBusinessId]);
 
   return null;
 }

--- a/src/components/messaging/MessageNotificationListener.tsx
+++ b/src/components/messaging/MessageNotificationListener.tsx
@@ -1,0 +1,144 @@
+import { useEffect, useRef } from "react";
+import { useLocation } from "react-router-dom";
+import { getCurrentUser } from "aws-amplify/auth";
+import { amplifyDataClient } from "@/amplifyDataClient";
+import { useAuth } from "@/contexts/AuthContext";
+import { toast } from "sonner";
+import { UPLIFT_REFRESH_CONVERSATIONS_EVENT } from "@/lib/messaging-events";
+
+const POLL_MS = 22_000;
+const MAX_TOASTS_PER_TICK = 2;
+
+type ConvRow = {
+  id: string;
+  lastMessage?: string | null;
+  lastMessageTimestamp?: string | null;
+  unreadCount?: number | null;
+  participantMuted?: boolean | null;
+  participantHidden?: boolean | null;
+  businessName?: string | null;
+};
+
+type RowSnap = { lm: string | null; ts: string | null; unread: number };
+type Snapshot = Record<string, RowSnap>;
+
+function getConversationModel() {
+  return (amplifyDataClient.models as { Conversation?: { list: (o: unknown) => Promise<{ data?: ConvRow[] }> } })
+    .Conversation;
+}
+
+/**
+ * Polls the conversation list while signed in and surfaces toasts / browser notifications
+ * when a thread updates while the user is not actively viewing that chat.
+ */
+export function MessageNotificationListener() {
+  const { user } = useAuth();
+  const location = useLocation();
+  const pathRef = useRef(location.pathname);
+  pathRef.current = location.pathname;
+
+  useEffect(() => {
+    if (!user) return;
+
+    let cancelled = false;
+    let snap: Snapshot | null = null;
+    let timer: ReturnType<typeof setInterval> | undefined;
+
+    const toSnapshot = (rows: ConvRow[]): Snapshot => {
+      const s: Snapshot = {};
+      for (const row of rows) {
+        s[row.id] = {
+          lm: row.lastMessage ?? null,
+          ts: row.lastMessageTimestamp ?? null,
+          unread: row.unreadCount ?? 0,
+        };
+      }
+      return s;
+    };
+
+    const tick = async () => {
+      if (cancelled) return;
+      try {
+        await getCurrentUser();
+      } catch {
+        snap = null;
+        return;
+      }
+
+      const model = getConversationModel();
+      if (!model) return;
+
+      const res = await model.list({ authMode: "userPool" });
+      const rows = (res?.data ?? []).filter((c) => !c.participantHidden);
+      const nextSnap = toSnapshot(rows);
+
+      const prev = snap;
+      if (prev) {
+        let shown = 0;
+        let anyChange = false;
+        for (const row of rows) {
+          if (row.participantMuted === true) continue;
+          let skipRecentOwnSend = false;
+          try {
+            const raw = sessionStorage.getItem("uplift:lastOwnMessage");
+            if (raw) {
+              const j = JSON.parse(raw) as { conversationId?: string; at?: number };
+              if (j.conversationId === row.id && typeof j.at === "number" && Date.now() - j.at < 8000) {
+                skipRecentOwnSend = true;
+              }
+            }
+          } catch {
+            // ignore
+          }
+          if (skipRecentOwnSend) continue;
+
+          const p = prev[row.id];
+          if (!p) continue;
+          const changed =
+            p.lm !== (row.lastMessage ?? null) ||
+            p.ts !== (row.lastMessageTimestamp ?? null) ||
+            p.unread !== (row.unreadCount ?? 0);
+          if (!changed) continue;
+          anyChange = true;
+
+          const threadPath = `/messages/${row.id}`;
+          if (pathRef.current === threadPath && typeof document !== "undefined" && !document.hidden) {
+            continue;
+          }
+
+          if (shown >= MAX_TOASTS_PER_TICK) continue;
+          shown += 1;
+          const title = row.businessName || "New message";
+          const body =
+            (row.lastMessage && String(row.lastMessage).slice(0, 140)) || "You have a new message";
+          toast.info(title, { description: body, duration: 6500 });
+          if (typeof Notification !== "undefined" && Notification.permission === "granted") {
+            try {
+              new Notification(title, { body, tag: `uplift-msg-${row.id}` });
+            } catch {
+              // ignore
+            }
+          }
+        }
+        if (anyChange) {
+          window.dispatchEvent(new Event(UPLIFT_REFRESH_CONVERSATIONS_EVENT));
+        }
+      }
+
+      snap = nextSnap;
+    };
+
+    void tick().then(() => {
+      if (!cancelled) {
+        timer = setInterval(() => void tick(), POLL_MS);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+      if (timer) clearInterval(timer);
+    };
+  }, [user?.userId]);
+
+  return null;
+}

--- a/src/hooks/useMessages.ts
+++ b/src/hooks/useMessages.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { amplifyDataClient } from '@/amplifyDataClient';
 import { getCurrentUser } from 'aws-amplify/auth';
+import { UPLIFT_REFRESH_CONVERSATIONS_EVENT } from '@/lib/messaging-events';
 
 function formatModelErrors(errors?: Array<{ message?: string }>): string | null {
   if (!errors || errors.length === 0) return null;
@@ -11,6 +12,9 @@ function formatModelErrors(errors?: Array<{ message?: string }>): string | null 
     .trim();
   return message || null;
 }
+
+/** URL segment for compose UI before a `Conversation` row exists in the backend. */
+export const MESSAGES_DRAFT_SEGMENT = 'new';
 
 function getModelOrThrow(modelName: 'Conversation' | 'Message') {
   const model = (amplifyDataClient.models as any)?.[modelName];
@@ -43,6 +47,7 @@ export interface ConversationItem {
   lastMessage?: string | null;
   lastMessageTimestamp?: string | null;
   unreadCount: number;
+  participantMuted: boolean;
 }
 
 export interface UseMessagesResult {
@@ -54,6 +59,11 @@ export interface UseMessagesResult {
   fetchMessages: (conversationId: string) => Promise<void>;
   createConversation: (businessId: string, businessName: string, businessImage?: string) => Promise<string>;
   markConversationAsRead: (conversationId: string) => Promise<void>;
+  /** Hide conversation for the current user only (soft delete on participant side). */
+  hideConversationForMe: (conversationId: string) => Promise<void>;
+  setConversationMuted: (conversationId: string, muted: boolean) => Promise<void>;
+  /** Clear loaded messages/errors (e.g. when opening a draft thread). */
+  resetThreadView: () => void;
 }
 
 export function useMessages(): UseMessagesResult {
@@ -62,15 +72,16 @@ export function useMessages(): UseMessagesResult {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
 
-  const fetchConversations = useCallback(async () => {
-    setLoading(true);
-    setError(null);
+  const fetchConversations = useCallback(async (options?: { quiet?: boolean }) => {
+    const quiet = options?.quiet === true;
+    if (!quiet) {
+      setLoading(true);
+      setError(null);
+    }
     try {
-      // First check if user is authenticated
       const user = await getCurrentUser();
       if (!user) {
         setConversations([]);
-        setLoading(false);
         return;
       }
 
@@ -87,27 +98,33 @@ export function useMessages(): UseMessagesResult {
 
       if (!res || !res.data) {
         setConversations([]);
-        setLoading(false);
         return;
       }
 
-      const items: ConversationItem[] = res.data.map((c: any): ConversationItem => ({
-        id: c.id,
-        participantId: c.participantId,
-        businessId: c.businessId,
-        businessName: c.businessName ?? null,
-        businessImage: c.businessImage ?? null,
-        lastMessage: c.lastMessage ?? null,
-        lastMessageTimestamp: c.lastMessageTimestamp ?? null,
-        unreadCount: c.unreadCount ?? 0,
-      }));
+      const items: ConversationItem[] = res.data
+        .filter((c: any) => !c.participantHidden)
+        .map((c: any): ConversationItem => ({
+          id: c.id,
+          participantId: c.participantId,
+          businessId: c.businessId,
+          businessName: c.businessName ?? null,
+          businessImage: c.businessImage ?? null,
+          lastMessage: c.lastMessage ?? null,
+          lastMessageTimestamp: c.lastMessageTimestamp ?? null,
+          unreadCount: c.unreadCount ?? 0,
+          participantMuted: c.participantMuted === true,
+        }));
       setConversations(items);
     } catch (err) {
       console.error('Error fetching conversations:', err);
-      setConversations([]);
-      setError(err instanceof Error ? err : new Error('Failed to fetch conversations'));
+      if (!quiet) {
+        setConversations([]);
+        setError(err instanceof Error ? err : new Error('Failed to fetch conversations'));
+      }
     } finally {
-      setLoading(false);
+      if (!quiet) {
+        setLoading(false);
+      }
     }
   }, []);
 
@@ -115,12 +132,26 @@ export function useMessages(): UseMessagesResult {
     fetchConversations();
   }, [fetchConversations]);
 
+  useEffect(() => {
+    const onRefresh = () => {
+      void fetchConversations({ quiet: true });
+    };
+    window.addEventListener(UPLIFT_REFRESH_CONVERSATIONS_EVENT, onRefresh);
+    return () => window.removeEventListener(UPLIFT_REFRESH_CONVERSATIONS_EVENT, onRefresh);
+  }, [fetchConversations]);
+
+  const resetThreadView = useCallback(() => {
+    setMessages([]);
+    setError(null);
+    setLoading(false);
+  }, []);
+
   const fetchMessages = useCallback(async (conversationId: string) => {
     setLoading(true);
     setError(null);
     try {
       const user = await getCurrentUser();
-      if (!user || !conversationId) {
+      if (!user || !conversationId || conversationId === MESSAGES_DRAFT_SEGMENT) {
         setMessages([]);
         setLoading(false);
         return;
@@ -222,6 +253,15 @@ export function useMessages(): UseMessagesResult {
 
         setMessages((prev) => [...prev, newMessage]);
 
+        try {
+          sessionStorage.setItem(
+            'uplift:lastOwnMessage',
+            JSON.stringify({ conversationId, at: Date.now() })
+          );
+        } catch {
+          // ignore
+        }
+
         // Update conversation's last message
         const conv = conversations.find((c) => c.id === conversationId);
         if (conv) {
@@ -269,6 +309,16 @@ export function useMessages(): UseMessagesResult {
 
         const existing = existingRes?.data?.find((c: any) => c.participantId === user.userId);
         if (existing?.id) {
+          if (existing.participantHidden === true) {
+            const unhideRes = await conversationModel.update(
+              { id: existing.id, participantHidden: false },
+              { authMode: 'userPool' }
+            );
+            const unhideErr = formatModelErrors(unhideRes?.errors);
+            if (unhideErr) {
+              throw new Error(unhideErr);
+            }
+          }
           return existing.id;
         }
 
@@ -279,6 +329,8 @@ export function useMessages(): UseMessagesResult {
             businessName,
             businessImage: businessImage || undefined,
             unreadCount: 0,
+            participantHidden: false,
+            participantMuted: false,
           },
           { authMode: 'userPool' }
         );
@@ -301,6 +353,7 @@ export function useMessages(): UseMessagesResult {
           lastMessage: null,
           lastMessageTimestamp: null,
           unreadCount: 0,
+          participantMuted: false,
         };
         setConversations((prev) => [...prev, newConversation]);
         return res.data.id;
@@ -343,6 +396,56 @@ export function useMessages(): UseMessagesResult {
     }
   }, []);
 
+  const hideConversationForMe = useCallback(async (conversationId: string) => {
+    const user = await getCurrentUser();
+    if (!user || !conversationId) {
+      throw new Error('User not authenticated');
+    }
+
+    const conversationModel = getModelOrThrow('Conversation');
+
+    const res = await conversationModel.update(
+      {
+        id: conversationId,
+        participantHidden: true,
+      },
+      { authMode: 'userPool' }
+    );
+    const modelError = formatModelErrors(res?.errors);
+    if (modelError) {
+      throw new Error(modelError);
+    }
+
+    setConversations((prev) => prev.filter((c) => c.id !== conversationId));
+    setMessages([]);
+    setError(null);
+  }, []);
+
+  const setConversationMuted = useCallback(async (conversationId: string, muted: boolean) => {
+    const user = await getCurrentUser();
+    if (!user || !conversationId) {
+      throw new Error('User not authenticated');
+    }
+
+    const conversationModel = getModelOrThrow('Conversation');
+
+    const res = await conversationModel.update(
+      {
+        id: conversationId,
+        participantMuted: muted,
+      },
+      { authMode: 'userPool' }
+    );
+    const modelError = formatModelErrors(res?.errors);
+    if (modelError) {
+      throw new Error(modelError);
+    }
+
+    setConversations((prev) =>
+      prev.map((c) => (c.id === conversationId ? { ...c, participantMuted: muted } : c))
+    );
+  }, []);
+
   return {
     conversations,
     messages,
@@ -352,5 +455,8 @@ export function useMessages(): UseMessagesResult {
     fetchMessages,
     createConversation,
     markConversationAsRead,
+    hideConversationForMe,
+    setConversationMuted,
+    resetThreadView,
   };
 }

--- a/src/hooks/useMessages.ts
+++ b/src/hooks/useMessages.ts
@@ -1,7 +1,10 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { amplifyDataClient } from '@/amplifyDataClient';
-import { getCurrentUser } from 'aws-amplify/auth';
+import { fetchUserAttributes, getCurrentUser } from 'aws-amplify/auth';
 import { UPLIFT_REFRESH_CONVERSATIONS_EVENT } from '@/lib/messaging-events';
+import { formatDisplayNameForReviews } from '@/lib/format-display-name';
+import { useAuth } from '@/contexts/AuthContext';
+import { useOwnerBusiness } from '@/hooks/useOwnerBusiness';
 
 function formatModelErrors(errors?: Array<{ message?: string }>): string | null {
   if (!errors || errors.length === 0) return null;
@@ -26,6 +29,35 @@ function getModelOrThrow(modelName: 'Conversation' | 'Message') {
   return model;
 }
 
+/** Matches review public name + profile photo (User.avatarUrl), not Cognito username/sub. */
+async function loadParticipantProfileForMessaging(): Promise<{
+  participantName: string;
+  participantAvatarUrl?: string;
+  senderLabel: string;
+}> {
+  let participantAvatarUrl: string | undefined;
+  try {
+    const list = await (amplifyDataClient.models as any).User.list({ authMode: 'userPool' });
+    const row = (list.data ?? [])[0] as { avatarUrl?: string | null } | undefined;
+    if (row?.avatarUrl?.trim()) participantAvatarUrl = row.avatarUrl.trim();
+  } catch {
+    // ignore
+  }
+
+  try {
+    const attrs = await fetchUserAttributes();
+    const formatted = formatDisplayNameForReviews(attrs.name as string | undefined).trim();
+    const participantName = formatted || 'Anonymous Customer';
+    return { participantName, participantAvatarUrl, senderLabel: participantName };
+  } catch {
+    return {
+      participantName: 'Anonymous Customer',
+      participantAvatarUrl,
+      senderLabel: 'Anonymous Customer',
+    };
+  }
+}
+
 export interface MessageItem {
   id: string;
   conversationId: string;
@@ -38,22 +70,36 @@ export interface MessageItem {
   createdAt: string;
 }
 
+/** Snippet for inbox / conversation preview (matches send path `[Attachment]`). */
+function messagePreviewLine(m: Pick<MessageItem, 'text' | 'attachmentUrl'>): string {
+  const t = (m.text ?? '').trim();
+  if (t) return t.length > 220 ? `${t.slice(0, 220)}…` : t;
+  if (m.attachmentUrl) return '[Attachment]';
+  return '';
+}
+
 export interface ConversationItem {
   id: string;
   participantId: string;
+  participantName?: string | null;
+  participantAvatarUrl?: string | null;
   businessId: string;
   businessName?: string | null;
   businessImage?: string | null;
   lastMessage?: string | null;
   lastMessageTimestamp?: string | null;
   unreadCount: number;
+  businessUnreadCount: number;
   participantMuted: boolean;
 }
 
 export interface UseMessagesResult {
   conversations: ConversationItem[];
   messages: MessageItem[];
+  /** List / inbox fetch in progress (not message thread). */
   loading: boolean;
+  /** Current thread message fetch in progress. */
+  messagesLoading: boolean;
   error: Error | null;
   sendMessage: (conversationId: string, text: string, attachment?: { type: string; url: string; name: string }) => Promise<void>;
   fetchMessages: (conversationId: string) => Promise<void>;
@@ -70,7 +116,13 @@ export function useMessages(): UseMessagesResult {
   const [conversations, setConversations] = useState<ConversationItem[]>([]);
   const [messages, setMessages] = useState<MessageItem[]>([]);
   const [loading, setLoading] = useState(false);
+  const [messagesLoading, setMessagesLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
+  const conversationsRef = useRef(conversations);
+  conversationsRef.current = conversations;
+  const { isBusiness } = useAuth();
+  const { backendRow } = useOwnerBusiness();
+  const ownBusinessId = backendRow?.id ?? null;
 
   const fetchConversations = useCallback(async (options?: { quiet?: boolean }) => {
     const quiet = options?.quiet === true;
@@ -106,12 +158,15 @@ export function useMessages(): UseMessagesResult {
         .map((c: any): ConversationItem => ({
           id: c.id,
           participantId: c.participantId,
+          participantName: c.participantName ?? null,
+          participantAvatarUrl: c.participantAvatarUrl ?? null,
           businessId: c.businessId,
           businessName: c.businessName ?? null,
           businessImage: c.businessImage ?? null,
           lastMessage: c.lastMessage ?? null,
           lastMessageTimestamp: c.lastMessageTimestamp ?? null,
           unreadCount: c.unreadCount ?? 0,
+          businessUnreadCount: c.businessUnreadCount ?? 0,
           participantMuted: c.participantMuted === true,
         }));
       setConversations(items);
@@ -143,17 +198,17 @@ export function useMessages(): UseMessagesResult {
   const resetThreadView = useCallback(() => {
     setMessages([]);
     setError(null);
-    setLoading(false);
+    setMessagesLoading(false);
   }, []);
 
   const fetchMessages = useCallback(async (conversationId: string) => {
-    setLoading(true);
+    setMessagesLoading(true);
     setError(null);
     try {
       const user = await getCurrentUser();
       if (!user || !conversationId || conversationId === MESSAGES_DRAFT_SEGMENT) {
         setMessages([]);
-        setLoading(false);
+        setMessagesLoading(false);
         return;
       }
 
@@ -173,7 +228,7 @@ export function useMessages(): UseMessagesResult {
 
       if (!res || !res.data) {
         setMessages([]);
-        setLoading(false);
+        setMessagesLoading(false);
         return;
       }
 
@@ -188,13 +243,35 @@ export function useMessages(): UseMessagesResult {
         attachmentName: m.attachmentName ?? null,
         createdAt: m.createdAt,
       }));
-      setMessages(items.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()));
+      const sorted = items.sort(
+        (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+      );
+      setMessages(sorted);
+
+      if (sorted.length > 0) {
+        const last = sorted[sorted.length - 1];
+        const line = messagePreviewLine(last);
+        const ts = last.createdAt;
+        setConversations((prev) =>
+          prev.map((c) => {
+            if (c.id !== conversationId) return c;
+            const previewText =
+              line || (last.attachmentUrl ? '[Attachment]' : null) || c.lastMessage;
+            if (!previewText && !ts) return c;
+            return {
+              ...c,
+              lastMessage: previewText ?? c.lastMessage,
+              lastMessageTimestamp: ts || c.lastMessageTimestamp,
+            };
+          })
+        );
+      }
     } catch (err) {
       console.error('Error fetching messages:', err);
       setMessages([]);
       setError(err instanceof Error ? err : new Error('Failed to fetch messages'));
     } finally {
-      setLoading(false);
+      setMessagesLoading(false);
     }
   }, []);
 
@@ -213,10 +290,12 @@ export function useMessages(): UseMessagesResult {
         const messageModel = getModelOrThrow('Message');
         const conversationModel = getModelOrThrow('Conversation');
 
+        const { senderLabel } = await loadParticipantProfileForMessaging();
+
         const messageInput: any = {
           conversationId,
           senderId: user.userId,
-          senderName: user.username || 'User',
+          senderName: senderLabel,
           text: text || null,
         };
 
@@ -262,29 +341,82 @@ export function useMessages(): UseMessagesResult {
           // ignore
         }
 
-        // Update conversation's last message
-        const conv = conversations.find((c) => c.id === conversationId);
-        if (conv) {
-          const updateRes = await conversationModel.update(
-            {
-              id: conversationId,
-              lastMessage: text || '[Attachment]',
-              lastMessageTimestamp: new Date().toISOString(),
-            },
-            { authMode: 'userPool' }
-          );
-          const updateError = formatModelErrors(updateRes?.errors);
-          if (updateError) {
-            throw new Error(updateError);
+        const snippet = text?.trim() ? text.trim() : attachment ? '[Attachment]' : '';
+        const ts = new Date().toISOString();
+
+        let conv = conversationsRef.current.find((c) => c.id === conversationId);
+        if (!conv) {
+          const listRes = await conversationModel.list({
+            filter: { id: { eq: conversationId } },
+            limit: 1,
+            authMode: 'userPool',
+          });
+          const row = listRes?.data?.[0] as any;
+          if (row) {
+            conv = {
+              id: row.id,
+              participantId: row.participantId,
+              participantName: row.participantName ?? null,
+              participantAvatarUrl: row.participantAvatarUrl ?? null,
+              businessId: row.businessId,
+              businessName: row.businessName ?? null,
+              businessImage: row.businessImage ?? null,
+              lastMessage: row.lastMessage ?? null,
+              lastMessageTimestamp: row.lastMessageTimestamp ?? null,
+              unreadCount: row.unreadCount ?? 0,
+              businessUnreadCount: row.businessUnreadCount ?? 0,
+              participantMuted: row.participantMuted === true,
+            };
           }
         }
+
+        let nextUnread = conv?.unreadCount ?? 0;
+        let nextBusinessUnread = conv?.businessUnreadCount ?? 0;
+        const participantId = conv?.participantId;
+        if (participantId) {
+          const isFromParticipant = user.userId === participantId;
+          if (isFromParticipant) {
+            nextBusinessUnread += 1;
+          } else {
+            nextUnread += 1;
+          }
+        }
+
+        const updateRes = await conversationModel.update(
+          {
+            id: conversationId,
+            lastMessage: snippet || '[Attachment]',
+            lastMessageTimestamp: ts,
+            unreadCount: nextUnread,
+            businessUnreadCount: nextBusinessUnread,
+          },
+          { authMode: 'userPool' }
+        );
+        const updateError = formatModelErrors(updateRes?.errors);
+        if (updateError) {
+          throw new Error(updateError);
+        }
+
+        setConversations((prev) =>
+          prev.map((c) =>
+            c.id === conversationId
+              ? {
+                  ...c,
+                  lastMessage: snippet || '[Attachment]',
+                  lastMessageTimestamp: ts,
+                  unreadCount: nextUnread,
+                  businessUnreadCount: nextBusinessUnread,
+                }
+              : c
+          )
+        );
       } catch (err) {
         console.error('Error sending message:', err);
         setError(err instanceof Error ? err : new Error('Failed to send message'));
         throw err;
       }
     },
-    [conversations]
+    []
   );
 
   const createConversation = useCallback(
@@ -297,7 +429,8 @@ export function useMessages(): UseMessagesResult {
 
         const conversationModel = getModelOrThrow('Conversation');
 
-        // Reuse existing conversation to avoid accidental duplicates.
+        // Reuse only a still-visible thread. If the user removed it from their inbox (hidden),
+        // start a new conversation so old messages stay with the archived row.
         const existingRes = await conversationModel.list({
           filter: { businessId: { eq: businessId } },
           authMode: 'userPool',
@@ -307,28 +440,58 @@ export function useMessages(): UseMessagesResult {
           throw new Error(existingError);
         }
 
-        const existing = existingRes?.data?.find((c: any) => c.participantId === user.userId);
-        if (existing?.id) {
-          if (existing.participantHidden === true) {
-            const unhideRes = await conversationModel.update(
-              { id: existing.id, participantHidden: false },
+        const active = existingRes?.data?.find(
+          (c: any) => c.participantId === user.userId && !c.participantHidden
+        );
+        if (active?.id) {
+          const pn = String(active.participantName ?? '').trim();
+          const stale =
+            !pn ||
+            pn === user.userId ||
+            pn === (user.username ?? '') ||
+            pn === 'Customer';
+          if (stale) {
+            const profile = await loadParticipantProfileForMessaging();
+            const patchRes = await conversationModel.update(
+              {
+                id: active.id,
+                participantName: profile.participantName,
+                participantAvatarUrl: profile.participantAvatarUrl,
+              },
               { authMode: 'userPool' }
             );
-            const unhideErr = formatModelErrors(unhideRes?.errors);
-            if (unhideErr) {
-              throw new Error(unhideErr);
+            const patchErr = formatModelErrors(patchRes?.errors);
+            if (patchErr) {
+              console.warn('Conversation profile backfill skipped:', patchErr);
+            } else {
+              setConversations((prev) =>
+                prev.map((c) =>
+                  c.id === active.id
+                    ? {
+                        ...c,
+                        participantName: profile.participantName,
+                        participantAvatarUrl: profile.participantAvatarUrl ?? null,
+                      }
+                    : c
+                )
+              );
             }
           }
-          return existing.id;
+          return active.id;
         }
+
+        const { participantName, participantAvatarUrl } = await loadParticipantProfileForMessaging();
 
         const res = await conversationModel.create(
           {
             participantId: user.userId,
+            participantName,
+            participantAvatarUrl,
             businessId,
             businessName,
             businessImage: businessImage || undefined,
             unreadCount: 0,
+            businessUnreadCount: 0,
             participantHidden: false,
             participantMuted: false,
           },
@@ -347,12 +510,15 @@ export function useMessages(): UseMessagesResult {
         const newConversation: ConversationItem = {
           id: res.data.id,
           participantId: res.data.participantId,
+          participantName: res.data.participantName ?? null,
+          participantAvatarUrl: res.data.participantAvatarUrl ?? null,
           businessId: res.data.businessId,
           businessName: res.data.businessName ?? null,
           businessImage: res.data.businessImage ?? null,
           lastMessage: null,
           lastMessageTimestamp: null,
           unreadCount: 0,
+          businessUnreadCount: 0,
           participantMuted: false,
         };
         setConversations((prev) => [...prev, newConversation]);
@@ -374,27 +540,75 @@ export function useMessages(): UseMessagesResult {
       }
 
       const conversationModel = getModelOrThrow('Conversation');
+      let conv = conversationsRef.current.find((c) => c.id === conversationId);
+      if (!conv) {
+        const listRes = await conversationModel.list({
+          filter: { id: { eq: conversationId } },
+          limit: 1,
+          authMode: 'userPool',
+        });
+        const row = listRes?.data?.[0] as any;
+        if (row) {
+          conv = {
+            id: row.id,
+            participantId: row.participantId,
+            participantName: row.participantName ?? null,
+            participantAvatarUrl: row.participantAvatarUrl ?? null,
+            businessId: row.businessId,
+            businessName: row.businessName ?? null,
+            businessImage: row.businessImage ?? null,
+            lastMessage: row.lastMessage ?? null,
+            lastMessageTimestamp: row.lastMessageTimestamp ?? null,
+            unreadCount: row.unreadCount ?? 0,
+            businessUnreadCount: row.businessUnreadCount ?? 0,
+            participantMuted: row.participantMuted === true,
+          };
+        }
+      }
 
-      const res = await conversationModel.update(
-        {
-          id: conversationId,
-          unreadCount: 0,
-        },
-        { authMode: 'userPool' }
-      );
+      const payload: {
+        id: string;
+        unreadCount?: number;
+        businessUnreadCount?: number;
+      } = { id: conversationId };
+
+      if (conv) {
+        if (user.userId === conv.participantId) {
+          payload.unreadCount = 0;
+        } else if (isBusiness && ownBusinessId && conv.businessId === ownBusinessId) {
+          payload.businessUnreadCount = 0;
+        } else {
+          payload.unreadCount = 0;
+          payload.businessUnreadCount = 0;
+        }
+      } else {
+        payload.unreadCount = 0;
+        payload.businessUnreadCount = 0;
+      }
+
+      const res = await conversationModel.update(payload, { authMode: 'userPool' });
       const modelError = formatModelErrors(res?.errors);
       if (modelError) {
         throw new Error(modelError);
       }
 
       setConversations((prev) =>
-        prev.map((c) => (c.id === conversationId ? { ...c, unreadCount: 0 } : c))
+        prev.map((c) => {
+          if (c.id !== conversationId) return c;
+          if (conv && user.userId === conv.participantId) {
+            return { ...c, unreadCount: 0 };
+          }
+          if (conv && isBusiness && ownBusinessId && conv.businessId === ownBusinessId) {
+            return { ...c, businessUnreadCount: 0 };
+          }
+          return { ...c, unreadCount: 0, businessUnreadCount: 0 };
+        })
       );
     } catch (err) {
       console.error('Error marking conversation as read:', err);
       setError(err instanceof Error ? err : new Error('Failed to mark conversation as read'));
     }
-  }, []);
+  }, [isBusiness, ownBusinessId]);
 
   const hideConversationForMe = useCallback(async (conversationId: string) => {
     const user = await getCurrentUser();
@@ -419,6 +633,7 @@ export function useMessages(): UseMessagesResult {
     setConversations((prev) => prev.filter((c) => c.id !== conversationId));
     setMessages([]);
     setError(null);
+    setMessagesLoading(false);
   }, []);
 
   const setConversationMuted = useCallback(async (conversationId: string, muted: boolean) => {
@@ -450,6 +665,7 @@ export function useMessages(): UseMessagesResult {
     conversations,
     messages,
     loading,
+    messagesLoading,
     error,
     sendMessage,
     fetchMessages,

--- a/src/hooks/useMessages.ts
+++ b/src/hooks/useMessages.ts
@@ -2,6 +2,26 @@ import { useState, useEffect, useCallback } from 'react';
 import { amplifyDataClient } from '@/amplifyDataClient';
 import { getCurrentUser } from 'aws-amplify/auth';
 
+function formatModelErrors(errors?: Array<{ message?: string }>): string | null {
+  if (!errors || errors.length === 0) return null;
+  const message = errors
+    .map((e) => e?.message)
+    .filter((m): m is string => Boolean(m && m.trim()))
+    .join('; ')
+    .trim();
+  return message || null;
+}
+
+function getModelOrThrow(modelName: 'Conversation' | 'Message') {
+  const model = (amplifyDataClient.models as any)?.[modelName];
+  if (!model) {
+    throw new Error(
+      `Messaging backend is not available (${modelName} model missing). Run backend sandbox/deploy and regenerate outputs.`
+    );
+  }
+  return model;
+}
+
 export interface MessageItem {
   id: string;
   conversationId: string;
@@ -54,9 +74,16 @@ export function useMessages(): UseMessagesResult {
         return;
       }
 
-      const res = await (amplifyDataClient.models as any)?.Conversation?.list({
+      const conversationModel = getModelOrThrow('Conversation');
+
+      const res = await conversationModel.list({
         authMode: 'userPool',
       });
+
+      const modelError = formatModelErrors(res?.errors);
+      if (modelError) {
+        throw new Error(modelError);
+      }
 
       if (!res || !res.data) {
         setConversations([]);
@@ -99,12 +126,19 @@ export function useMessages(): UseMessagesResult {
         return;
       }
 
-      const res = await (amplifyDataClient.models as any)?.Message?.list({
+      const messageModel = getModelOrThrow('Message');
+
+      const res = await messageModel.list({
         filter: {
           conversationId: { eq: conversationId },
         },
         authMode: 'userPool',
       });
+
+      const modelError = formatModelErrors(res?.errors);
+      if (modelError) {
+        throw new Error(modelError);
+      }
 
       if (!res || !res.data) {
         setMessages([]);
@@ -145,6 +179,9 @@ export function useMessages(): UseMessagesResult {
           throw new Error('User not authenticated or no conversation selected');
         }
 
+        const messageModel = getModelOrThrow('Message');
+        const conversationModel = getModelOrThrow('Conversation');
+
         const messageInput: any = {
           conversationId,
           senderId: user.userId,
@@ -158,9 +195,14 @@ export function useMessages(): UseMessagesResult {
           messageInput.attachmentName = attachment.name;
         }
 
-        const res = await (amplifyDataClient.models as any)?.Message?.create(messageInput, {
+        const res = await messageModel.create(messageInput, {
           authMode: 'userPool',
         });
+
+        const modelError = formatModelErrors(res?.errors);
+        if (modelError) {
+          throw new Error(modelError);
+        }
 
         if (!res || !res.data) {
           throw new Error('Failed to create message');
@@ -183,7 +225,7 @@ export function useMessages(): UseMessagesResult {
         // Update conversation's last message
         const conv = conversations.find((c) => c.id === conversationId);
         if (conv) {
-          await (amplifyDataClient.models as any)?.Conversation?.update(
+          const updateRes = await conversationModel.update(
             {
               id: conversationId,
               lastMessage: text || '[Attachment]',
@@ -191,6 +233,10 @@ export function useMessages(): UseMessagesResult {
             },
             { authMode: 'userPool' }
           );
+          const updateError = formatModelErrors(updateRes?.errors);
+          if (updateError) {
+            throw new Error(updateError);
+          }
         }
       } catch (err) {
         console.error('Error sending message:', err);
@@ -209,16 +255,38 @@ export function useMessages(): UseMessagesResult {
           throw new Error('User not authenticated');
         }
 
-        const res = await (amplifyDataClient.models as any)?.Conversation?.create(
+        const conversationModel = getModelOrThrow('Conversation');
+
+        // Reuse existing conversation to avoid accidental duplicates.
+        const existingRes = await conversationModel.list({
+          filter: { businessId: { eq: businessId } },
+          authMode: 'userPool',
+        });
+        const existingError = formatModelErrors(existingRes?.errors);
+        if (existingError) {
+          throw new Error(existingError);
+        }
+
+        const existing = existingRes?.data?.find((c: any) => c.participantId === user.userId);
+        if (existing?.id) {
+          return existing.id;
+        }
+
+        const res = await conversationModel.create(
           {
             participantId: user.userId,
             businessId,
             businessName,
-            businessImage: businessImage || null,
+            businessImage: businessImage || undefined,
             unreadCount: 0,
           },
           { authMode: 'userPool' }
         );
+
+        const modelError = formatModelErrors(res?.errors);
+        if (modelError) {
+          throw new Error(modelError);
+        }
 
         if (!res || !res.data) {
           throw new Error('Failed to create conversation');
@@ -252,13 +320,19 @@ export function useMessages(): UseMessagesResult {
         return;
       }
 
-      await (amplifyDataClient.models as any)?.Conversation?.update(
+      const conversationModel = getModelOrThrow('Conversation');
+
+      const res = await conversationModel.update(
         {
           id: conversationId,
           unreadCount: 0,
         },
         { authMode: 'userPool' }
       );
+      const modelError = formatModelErrors(res?.errors);
+      if (modelError) {
+        throw new Error(modelError);
+      }
 
       setConversations((prev) =>
         prev.map((c) => (c.id === conversationId ? { ...c, unreadCount: 0 } : c))

--- a/src/lib/format-display-name.ts
+++ b/src/lib/format-display-name.ts
@@ -1,0 +1,11 @@
+/**
+ * Same public label as reviews: "Hannah Gollner" → "Hannah G."
+ * @see ReviewForm — keep in sync for messaging and reviews.
+ */
+export function formatDisplayNameForReviews(fullName: string | undefined): string {
+  if (!fullName) return "";
+  const parts = fullName.trim().split(/\s+/);
+  const first = parts[0] ?? "";
+  const lastInitial = parts.length > 1 ? ` ${parts[parts.length - 1][0].toUpperCase()}.` : "";
+  return `${first}${lastInitial}`.trim();
+}

--- a/src/lib/gemini-chat.ts
+++ b/src/lib/gemini-chat.ts
@@ -41,3 +41,28 @@ export async function sendUpliftMessage(chat: ChatSession, text: string): Promis
   const result = await chat.sendMessage(text);
   return result.response.text();
 }
+
+/**
+ * Local fallback so the assistant remains usable when no Gemini key is configured.
+ */
+export function getUpliftFallbackReply(text: string): string {
+  const q = text.toLowerCase();
+
+  if (q.includes("near me") || q.includes("nearby") || q.includes("find")) {
+    return "Open Discover/Search, allow location access if prompted, then use category and tag filters to narrow nearby minority-owned businesses.";
+  }
+
+  if (q.includes("verified")) {
+    return "Verified means the business has completed Uplift's verification flow. It helps signal trust, but you can still compare reviews, ratings, and profile details.";
+  }
+
+  if (q.includes("join") || q.includes("register") || q.includes("owner") || q.includes("business")) {
+    return "Business owners can register from the Register flow, complete profile details, and submit verification. After approval, the profile becomes publicly visible.";
+  }
+
+  if (q.includes("message") || q.includes("chat")) {
+    return "You can message from the Messages area or from a business profile via the Message action. Conversations are grouped per business.";
+  }
+
+  return "I can help with finding businesses, understanding verification, messaging, favorites, and business onboarding in Uplift. Ask a specific task and I will walk you through it.";
+}

--- a/src/lib/messaging-counterparty.ts
+++ b/src/lib/messaging-counterparty.ts
@@ -1,0 +1,64 @@
+/**
+ * Who to show in thread/inbox headers: customer sees the business; business owner sees the customer.
+ */
+export type ConversationCounterpartyInput = {
+  participantId: string;
+  businessId: string;
+  businessName?: string | null;
+  businessImage?: string | null;
+  participantName?: string | null;
+  participantAvatarUrl?: string | null;
+};
+
+export type ConversationViewerContext = {
+  userId: string;
+  isBusiness: boolean;
+  /** Amplify `Business.id` for the signed-in owner, when `isBusiness`. */
+  ownBusinessId: string | null;
+};
+
+export type CounterpartyDisplay = {
+  title: string;
+  image: string | null;
+};
+
+/** Unread count for the signed-in viewer (customer vs business owner use different fields). */
+export type ConversationUnreadInput = ConversationCounterpartyInput & {
+  unreadCount?: number | null;
+  businessUnreadCount?: number | null;
+};
+
+export function getViewerUnreadCount(
+  conv: ConversationUnreadInput,
+  viewer: ConversationViewerContext
+): number {
+  if (viewer.userId === conv.participantId) {
+    return Math.max(0, Number(conv.unreadCount ?? 0));
+  }
+  if (viewer.isBusiness && viewer.ownBusinessId && conv.businessId === viewer.ownBusinessId) {
+    return Math.max(0, Number(conv.businessUnreadCount ?? 0));
+  }
+  return 0;
+}
+
+export function getConversationCounterparty(
+  conv: ConversationCounterpartyInput,
+  viewer: ConversationViewerContext
+): CounterpartyDisplay {
+  if (viewer.userId === conv.participantId) {
+    return {
+      title: conv.businessName?.trim() || "Business",
+      image: conv.businessImage ?? null,
+    };
+  }
+  if (viewer.isBusiness && viewer.ownBusinessId && conv.businessId === viewer.ownBusinessId) {
+    return {
+      title: conv.participantName?.trim() || "Customer",
+      image: conv.participantAvatarUrl ?? null,
+    };
+  }
+  return {
+    title: conv.businessName?.trim() || "Business",
+    image: conv.businessImage ?? null,
+  };
+}

--- a/src/lib/messaging-events.ts
+++ b/src/lib/messaging-events.ts
@@ -1,0 +1,2 @@
+/** Dispatched when conversation list should be re-synced from the server (e.g. after a remote message). */
+export const UPLIFT_REFRESH_CONVERSATIONS_EVENT = 'uplift:refresh-conversations';

--- a/src/lib/messaging-notifications.ts
+++ b/src/lib/messaging-notifications.ts
@@ -1,0 +1,7 @@
+/** Ask the browser to show system notifications for new messages (user gesture recommended). */
+export async function requestDesktopMessageNotifications(): Promise<NotificationPermission> {
+  if (typeof Notification === "undefined") {
+    return "denied";
+  }
+  return Notification.requestPermission();
+}

--- a/src/pages/BusinessProfile.tsx
+++ b/src/pages/BusinessProfile.tsx
@@ -1,9 +1,9 @@
 import { useParams } from "react-router-dom";
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { useBusinessProfile } from "@/hooks/useBusinessProfile";
 import { useReviews } from "@/hooks/useReviews";
-import { useMessages } from "@/hooks/useMessages";
+import { useMessages, MESSAGES_DRAFT_SEGMENT } from "@/hooks/useMessages";
 import { useAuth } from "@/contexts/AuthContext";
 import { BusinessProfileLayout } from "@/components/business-profile/BusinessProfileLayout";
 import { BusinessProfileSkeleton } from "@/components/business-profile/BusinessProfileSkeleton";
@@ -22,16 +22,15 @@ export default function BusinessProfilePage() {
   const { user } = useAuth();
   const { business, loading, error, refetch } = useBusinessProfile(id);
   const { reviews, submitting, submitReview } = useReviews(id);
-  const { conversations, createConversation } = useMessages();
-  const [startingConversation, setStartingConversation] = useState(false);
+  const { conversations } = useMessages();
 
   const existingConversationId = useMemo(() => {
     if (!business) return null;
     return conversations.find((c) => c.businessId === business.id)?.id ?? null;
   }, [business, conversations]);
 
-  const handleMessageBusiness = async () => {
-    if (!business || startingConversation) return;
+  const handleMessageBusiness = () => {
+    if (!business) return;
 
     if (!user) {
       toast.info("Please sign in to message this business.");
@@ -39,20 +38,19 @@ export default function BusinessProfilePage() {
       return;
     }
 
-    try {
-      setStartingConversation(true);
+    const state = {
+      businessName: business.name,
+      businessImage: business.images[0],
+      businessId: business.id,
+    };
 
-      const conversationId =
-        existingConversationId ??
-        (await createConversation(business.id, business.name, business.images[0]));
-
-      navigate(`/messages/${conversationId}`);
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : "Could not start conversation";
-      toast.error("Unable to message business", { description: msg });
-    } finally {
-      setStartingConversation(false);
+    if (existingConversationId) {
+      navigate(`/messages/${existingConversationId}`, { state });
+      return;
     }
+
+    // No DB row until the user sends their first message.
+    navigate(`/messages/${MESSAGES_DRAFT_SEGMENT}`, { state });
   };
 
   if (loading) {
@@ -96,7 +94,6 @@ export default function BusinessProfilePage() {
         onSubmitReview={submitReview}
         submittingReview={submitting}
         onMessageBusiness={handleMessageBusiness}
-        messagingInProgress={startingConversation}
         backHref="/search"
       />
     </div>

--- a/src/pages/BusinessProfile.tsx
+++ b/src/pages/BusinessProfile.tsx
@@ -1,10 +1,15 @@
 import { useParams } from "react-router-dom";
+import { useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { useBusinessProfile } from "@/hooks/useBusinessProfile";
 import { useReviews } from "@/hooks/useReviews";
+import { useMessages } from "@/hooks/useMessages";
+import { useAuth } from "@/contexts/AuthContext";
 import { BusinessProfileLayout } from "@/components/business-profile/BusinessProfileLayout";
 import { BusinessProfileSkeleton } from "@/components/business-profile/BusinessProfileSkeleton";
 import { ErrorState } from "@/components/shared";
 import { Navigation } from "@/components/Navigation";
+import { toast } from "sonner";
 
 /**
  * Public business profile page. Fetches business by ID from /api/business/:id,
@@ -12,9 +17,43 @@ import { Navigation } from "@/components/Navigation";
  * layout with data on success.
  */
 export default function BusinessProfilePage() {
+  const navigate = useNavigate();
   const { id } = useParams<{ id: string }>();
+  const { user } = useAuth();
   const { business, loading, error, refetch } = useBusinessProfile(id);
   const { reviews, submitting, submitReview } = useReviews(id);
+  const { conversations, createConversation } = useMessages();
+  const [startingConversation, setStartingConversation] = useState(false);
+
+  const existingConversationId = useMemo(() => {
+    if (!business) return null;
+    return conversations.find((c) => c.businessId === business.id)?.id ?? null;
+  }, [business, conversations]);
+
+  const handleMessageBusiness = async () => {
+    if (!business || startingConversation) return;
+
+    if (!user) {
+      toast.info("Please sign in to message this business.");
+      navigate("/auth");
+      return;
+    }
+
+    try {
+      setStartingConversation(true);
+
+      const conversationId =
+        existingConversationId ??
+        (await createConversation(business.id, business.name, business.images[0]));
+
+      navigate(`/messages/${conversationId}`);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "Could not start conversation";
+      toast.error("Unable to message business", { description: msg });
+    } finally {
+      setStartingConversation(false);
+    }
+  };
 
   if (loading) {
     return (
@@ -56,6 +95,8 @@ export default function BusinessProfilePage() {
         reviewsPreview={reviews.slice(0, 3)}
         onSubmitReview={submitReview}
         submittingReview={submitting}
+        onMessageBusiness={handleMessageBusiness}
+        messagingInProgress={startingConversation}
         backHref="/search"
       />
     </div>

--- a/src/pages/Messages.tsx
+++ b/src/pages/Messages.tsx
@@ -1,41 +1,125 @@
-import { useEffect, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
-import { ArrowLeft, Send, Paperclip, Star, MapPin } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { useLocation, useNavigate, useParams } from "react-router-dom";
+import { ArrowLeft, Send, Paperclip } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Badge } from "@/components/ui/badge";
 import { Navigation } from "@/components/Navigation";
-import { useMessages } from "@/hooks/useMessages";
-import { useAuthenticator } from "@aws-amplify/ui-react";
+import { useMessages, MESSAGES_DRAFT_SEGMENT } from "@/hooks/useMessages";
+import { useAuth } from "@/contexts/AuthContext";
+import { toast } from "sonner";
+import { DeleteConversationForMeDialog } from "@/components/messaging/DeleteConversationForMeDialog";
+import { ConversationChatMenu } from "@/components/messaging/ConversationChatMenu";
+
+/** Passed from BusinessProfile when starting a thread so the header works before the inbox refetches. */
+export type MessagesLocationState = {
+  businessName?: string;
+  businessImage?: string;
+  businessId?: string;
+};
 
 const Messages = () => {
   const navigate = useNavigate();
+  const location = useLocation();
   const { conversationId } = useParams<{ conversationId: string }>();
-  const { user } = useAuthenticator();
-  const { messages, loading, error, sendMessage, fetchMessages, conversations } = useMessages();
+  const { user } = useAuth();
+  const {
+    messages,
+    loading,
+    error,
+    sendMessage,
+    fetchMessages,
+    createConversation,
+    conversations,
+    resetThreadView,
+    hideConversationForMe,
+    setConversationMuted,
+  } = useMessages();
   const [messageText, setMessageText] = useState("");
   const [sending, setSending] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [deletePending, setDeletePending] = useState(false);
+  const [muteBusy, setMuteBusy] = useState(false);
 
-  // Find the current conversation
-  const conversation = conversations.find((c) => c.id === conversationId);
+  const navState = (location.state ?? null) as MessagesLocationState | null;
+
+  const conversation = useMemo(() => {
+    if (conversationId === MESSAGES_DRAFT_SEGMENT) {
+      if (!navState?.businessId || !navState?.businessName) return undefined;
+      return {
+        id: MESSAGES_DRAFT_SEGMENT,
+        participantId: user?.userId ?? "",
+        businessId: navState.businessId,
+        businessName: navState.businessName,
+        businessImage: navState.businessImage ?? null,
+        lastMessage: null as string | null,
+        lastMessageTimestamp: null as string | null,
+        unreadCount: 0,
+        participantMuted: false,
+      };
+    }
+    const fromList = conversations.find((c) => c.id === conversationId);
+    if (fromList) return fromList;
+    if (!conversationId || !navState?.businessName) return undefined;
+    return {
+      id: conversationId,
+      participantId: user?.userId ?? "",
+      businessId: navState.businessId ?? "",
+      businessName: navState.businessName,
+      businessImage: navState.businessImage ?? null,
+      lastMessage: null as string | null,
+      lastMessageTimestamp: null as string | null,
+      unreadCount: 0,
+      participantMuted: false,
+    };
+  }, [conversations, conversationId, navState, user?.userId]);
 
   useEffect(() => {
-    if (conversationId) {
-      fetchMessages(conversationId);
+    if (!conversationId) return;
+    if (conversationId === MESSAGES_DRAFT_SEGMENT) {
+      resetThreadView();
+      return;
     }
-  }, [conversationId, fetchMessages]);
+    fetchMessages(conversationId);
+  }, [conversationId, fetchMessages, resetThreadView]);
 
   const handleSend = async () => {
     if (!messageText.trim() || !conversationId || sending) return;
 
     try {
       setSending(true);
-      await sendMessage(conversationId, messageText.trim());
+      let activeId = conversationId;
+      if (conversationId === MESSAGES_DRAFT_SEGMENT) {
+        if (!navState?.businessId || !navState?.businessName) {
+          toast.error("Missing business info", {
+            description: "Go back to the business profile and tap Message again.",
+          });
+          return;
+        }
+        activeId = await createConversation(
+          navState.businessId,
+          navState.businessName,
+          navState.businessImage ?? undefined
+        );
+      }
+      await sendMessage(activeId, messageText.trim());
+      if (conversationId === MESSAGES_DRAFT_SEGMENT && navState) {
+        navigate(`/messages/${activeId}`, {
+          replace: true,
+          state: {
+            businessId: navState.businessId,
+            businessName: navState.businessName,
+            businessImage: navState.businessImage,
+          },
+        });
+      }
       setMessageText("");
     } catch (err) {
-      console.error('Failed to send message:', err);
+      console.error("Failed to send message:", err);
+      toast.error("Could not send message", {
+        description: err instanceof Error ? err.message : undefined,
+      });
     } finally {
       setSending(false);
     }
@@ -47,15 +131,42 @@ const Messages = () => {
 
     try {
       setSending(true);
+      let activeId = conversationId;
+      if (conversationId === MESSAGES_DRAFT_SEGMENT) {
+        if (!navState?.businessId || !navState?.businessName) {
+          toast.error("Missing business info", {
+            description: "Go back to the business profile and tap Message again.",
+          });
+          return;
+        }
+        activeId = await createConversation(
+          navState.businessId,
+          navState.businessName,
+          navState.businessImage ?? undefined
+        );
+      }
       const url = URL.createObjectURL(file);
       const attachmentType = file.type.startsWith("image/") ? "image" : "file";
-      await sendMessage(conversationId, "", {
+      await sendMessage(activeId, "", {
         type: attachmentType,
         url,
         name: file.name,
       });
+      if (conversationId === MESSAGES_DRAFT_SEGMENT && navState) {
+        navigate(`/messages/${activeId}`, {
+          replace: true,
+          state: {
+            businessId: navState.businessId,
+            businessName: navState.businessName,
+            businessImage: navState.businessImage,
+          },
+        });
+      }
     } catch (err) {
-      console.error('Failed to upload file:', err);
+      console.error("Failed to upload file:", err);
+      toast.error("Could not send attachment", {
+        description: err instanceof Error ? err.message : undefined,
+      });
     } finally {
       setSending(false);
     }
@@ -70,9 +181,34 @@ const Messages = () => {
     });
   };
 
+  const canOpenThreadMenu =
+    Boolean(conversationId) &&
+    conversationId !== MESSAGES_DRAFT_SEGMENT &&
+    Boolean(conversation);
+
   return (
-    <div className="flex flex-col min-h-screen bg-background">
+    <div className="flex h-dvh min-h-0 flex-col overflow-hidden bg-background">
       <Navigation />
+      <DeleteConversationForMeDialog
+        open={deleteOpen}
+        onOpenChange={setDeleteOpen}
+        pending={deletePending}
+        onConfirm={async () => {
+          if (!conversationId || conversationId === MESSAGES_DRAFT_SEGMENT) return;
+          setDeletePending(true);
+          try {
+            await hideConversationForMe(conversationId);
+            navigate("/messages");
+          } catch (err) {
+            toast.error("Couldn't remove chat", {
+              description: err instanceof Error ? err.message : undefined,
+            });
+            throw err; // Dialog stays open (see DeleteConversationForMeDialog).
+          } finally {
+            setDeletePending(false);
+          }
+        }}
+      />
       {/* Header with Business Info */}
       <div className="border-b border-border bg-card">
         <div className="container max-w-4xl mx-auto px-4 py-4">
@@ -87,7 +223,11 @@ const Messages = () => {
             </Button>
 
             {!conversation ? (
-              <div className="text-muted-foreground">Loading conversation...</div>
+              <div className="text-muted-foreground">
+                {conversationId === MESSAGES_DRAFT_SEGMENT
+                  ? "Open Message from a business profile to start chatting."
+                  : "Loading conversation..."}
+              </div>
             ) : (
               <div className="flex items-center gap-3 flex-1 min-w-0">
                 <Avatar className="h-12 w-12 shrink-0">
@@ -102,6 +242,32 @@ const Messages = () => {
                     </h2>
                   </div>
                 </div>
+                {canOpenThreadMenu && (
+                  <ConversationChatMenu
+                    openable
+                    participantMuted={conversation.participantMuted}
+                    muteBusy={muteBusy}
+                    onToggleMute={async () => {
+                      if (!conversationId || conversationId === MESSAGES_DRAFT_SEGMENT) return;
+                      try {
+                        setMuteBusy(true);
+                        await setConversationMuted(conversationId, !conversation.participantMuted);
+                        toast.success(
+                          conversation.participantMuted
+                            ? "Conversation unmuted"
+                            : "Conversation muted — alerts paused for this chat"
+                        );
+                      } catch (e) {
+                        toast.error("Could not update mute", {
+                          description: e instanceof Error ? e.message : undefined,
+                        });
+                      } finally {
+                        setMuteBusy(false);
+                      }
+                    }}
+                    onRequestDelete={() => setDeleteOpen(true)}
+                  />
+                )}
               </div>
             )}
           </div>
@@ -109,7 +275,7 @@ const Messages = () => {
       </div>
 
       {/* Messages Area */}
-      <ScrollArea className="flex-1">
+      <ScrollArea className="flex-1 min-h-0">
         <div className="container max-w-4xl mx-auto px-4 py-6">
           {error && (
             <div className="p-4 mb-4 bg-destructive/10 text-destructive rounded">
@@ -117,7 +283,7 @@ const Messages = () => {
             </div>
           )}
           <div className="space-y-4">
-            {loading ? (
+            {loading && conversationId !== MESSAGES_DRAFT_SEGMENT ? (
               <div className="text-center text-muted-foreground">Loading messages...</div>
             ) : messages.length === 0 ? (
               <div className="text-center text-muted-foreground">No messages yet. Start the conversation!</div>
@@ -200,13 +366,13 @@ const Messages = () => {
               value={messageText}
               onChange={(e) => setMessageText(e.target.value)}
               onKeyPress={(e) => e.key === "Enter" && handleSend()}
-              disabled={sending || !conversationId}
+              disabled={sending || !conversationId || !conversation}
               className="flex-1"
             />
 
             <Button
               onClick={handleSend}
-              disabled={!messageText.trim() || sending || !conversationId}
+              disabled={!messageText.trim() || sending || !conversationId || !conversation}
               className="shrink-0"
             >
               <Send className="h-4 w-4" />

--- a/src/pages/Messages.tsx
+++ b/src/pages/Messages.tsx
@@ -8,7 +8,10 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Navigation } from "@/components/Navigation";
 import { useMessages, MESSAGES_DRAFT_SEGMENT } from "@/hooks/useMessages";
 import { useAuth } from "@/contexts/AuthContext";
+import { useOwnerBusiness } from "@/hooks/useOwnerBusiness";
+import { getConversationCounterparty, getViewerUnreadCount } from "@/lib/messaging-counterparty";
 import { toast } from "sonner";
+import { formatDistanceToNow } from "date-fns";
 import { DeleteConversationForMeDialog } from "@/components/messaging/DeleteConversationForMeDialog";
 import { ConversationChatMenu } from "@/components/messaging/ConversationChatMenu";
 
@@ -23,10 +26,12 @@ const Messages = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const { conversationId } = useParams<{ conversationId: string }>();
-  const { user } = useAuth();
+  const { user, isBusiness } = useAuth();
+  const { backendRow } = useOwnerBusiness();
+  const ownBusinessId = backendRow?.id ?? null;
   const {
     messages,
-    loading,
+    messagesLoading,
     error,
     sendMessage,
     fetchMessages,
@@ -35,6 +40,7 @@ const Messages = () => {
     resetThreadView,
     hideConversationForMe,
     setConversationMuted,
+    markConversationAsRead,
   } = useMessages();
   const [messageText, setMessageText] = useState("");
   const [sending, setSending] = useState(false);
@@ -56,6 +62,7 @@ const Messages = () => {
         lastMessage: null as string | null,
         lastMessageTimestamp: null as string | null,
         unreadCount: 0,
+        businessUnreadCount: 0,
         participantMuted: false,
       };
     }
@@ -71,9 +78,44 @@ const Messages = () => {
       lastMessage: null as string | null,
       lastMessageTimestamp: null as string | null,
       unreadCount: 0,
+      businessUnreadCount: 0,
       participantMuted: false,
     };
   }, [conversations, conversationId, navState, user?.userId]);
+
+  const viewerUnread = useMemo(() => {
+    if (!conversation || !user) return 0;
+    return getViewerUnreadCount(conversation, {
+      userId: user.userId,
+      isBusiness,
+      ownBusinessId,
+    });
+  }, [conversation, user, isBusiness, ownBusinessId]);
+
+  const counterparty = useMemo(() => {
+    if (!conversation || !user) return null;
+    const viewer = { userId: user.userId, isBusiness, ownBusinessId };
+    const base = getConversationCounterparty(conversation, viewer);
+    const isOwnerViewingCustomer =
+      user.userId !== conversation.participantId &&
+      isBusiness &&
+      ownBusinessId &&
+      conversation.businessId === ownBusinessId;
+    if (isOwnerViewingCustomer && !conversation.participantName?.trim()) {
+      const fromMsg = messages
+        .find((m) => m.senderId === conversation.participantId)
+        ?.senderName?.trim();
+      if (fromMsg) return { ...base, title: fromMsg };
+    }
+    const isCustomerViewingBusiness = user.userId === conversation.participantId;
+    if (isCustomerViewingBusiness && !conversation.businessName?.trim()) {
+      const fromMsg = messages
+        .find((m) => m.senderId !== conversation.participantId)
+        ?.senderName?.trim();
+      if (fromMsg) return { ...base, title: fromMsg };
+    }
+    return base;
+  }, [conversation, user, isBusiness, ownBusinessId, messages]);
 
   useEffect(() => {
     if (!conversationId) return;
@@ -83,6 +125,11 @@ const Messages = () => {
     }
     fetchMessages(conversationId);
   }, [conversationId, fetchMessages, resetThreadView]);
+
+  useEffect(() => {
+    if (!conversationId || conversationId === MESSAGES_DRAFT_SEGMENT) return;
+    void markConversationAsRead(conversationId);
+  }, [conversationId, markConversationAsRead]);
 
   const handleSend = async () => {
     if (!messageText.trim() || !conversationId || sending) return;
@@ -181,6 +228,13 @@ const Messages = () => {
     });
   };
 
+  const formatMessageAge = (iso: string | null | undefined) => {
+    if (!iso) return null;
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return null;
+    return formatDistanceToNow(d, { addSuffix: true });
+  };
+
   const canOpenThreadMenu =
     Boolean(conversationId) &&
     conversationId !== MESSAGES_DRAFT_SEGMENT &&
@@ -209,7 +263,7 @@ const Messages = () => {
           }
         }}
       />
-      {/* Header with Business Info */}
+      {/* Header: customer sees business; business owner sees customer */}
       <div className="border-b border-border bg-card">
         <div className="container max-w-4xl mx-auto px-4 py-4">
           <div className="flex items-center gap-4">
@@ -231,15 +285,23 @@ const Messages = () => {
             ) : (
               <div className="flex items-center gap-3 flex-1 min-w-0">
                 <Avatar className="h-12 w-12 shrink-0">
-                  <AvatarImage src={conversation.businessImage || undefined} alt={conversation.businessName || 'Business'} />
-                  <AvatarFallback>{(conversation.businessName || 'B')[0]}</AvatarFallback>
+                  <AvatarImage
+                    src={counterparty?.image || undefined}
+                    alt={counterparty?.title || "Chat"}
+                  />
+                  <AvatarFallback>{(counterparty?.title || "C")[0]}</AvatarFallback>
                 </Avatar>
 
                 <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2 mb-1">
+                  <div className="flex flex-wrap items-center gap-2 mb-1">
                     <h2 className="font-semibold text-foreground truncate">
-                      {conversation.businessName || 'Business'}
+                      {counterparty?.title || "Chat"}
                     </h2>
+                    {viewerUnread > 0 && (
+                      <span className="shrink-0 rounded-full bg-primary/15 px-2 py-0.5 text-xs font-semibold text-primary">
+                        Unread
+                      </span>
+                    )}
                   </div>
                 </div>
                 {canOpenThreadMenu && (
@@ -283,11 +345,9 @@ const Messages = () => {
             </div>
           )}
           <div className="space-y-4">
-            {loading && conversationId !== MESSAGES_DRAFT_SEGMENT ? (
+            {messagesLoading && conversationId !== MESSAGES_DRAFT_SEGMENT ? (
               <div className="text-center text-muted-foreground">Loading messages...</div>
-            ) : messages.length === 0 ? (
-              <div className="text-center text-muted-foreground">No messages yet. Start the conversation!</div>
-            ) : (
+            ) : messages.length > 0 ? (
               messages.map((message) => {
                 const isOwnMessage = message.senderId === user?.userId;
                 return (
@@ -334,6 +394,56 @@ const Messages = () => {
                   </div>
                 );
               })
+            ) : conversation &&
+              conversationId !== MESSAGES_DRAFT_SEGMENT &&
+              (conversation.lastMessage?.trim() || conversation.lastMessageTimestamp) ? (
+              <div
+                className={`mx-auto max-w-md rounded-lg border p-6 text-left ${
+                  viewerUnread > 0
+                    ? "border-primary/50 bg-primary/5 shadow-sm"
+                    : "border-border bg-muted/40"
+                }`}
+              >
+                <div className="mb-2 flex items-center gap-2">
+                  {viewerUnread > 0 && (
+                    <span
+                      className="inline-flex h-2 w-2 shrink-0 rounded-full bg-primary shadow-sm ring-2 ring-primary/25"
+                      aria-hidden
+                    />
+                  )}
+                  <p
+                    className={`text-xs uppercase tracking-wide ${
+                      viewerUnread > 0
+                        ? "font-bold text-primary"
+                        : "font-medium text-muted-foreground"
+                    }`}
+                  >
+                    {viewerUnread > 0 ? "Unread · latest message" : "Latest message"}
+                  </p>
+                </div>
+                <p
+                  className={`text-sm leading-relaxed whitespace-pre-wrap break-words ${
+                    viewerUnread > 0
+                      ? "font-bold text-foreground"
+                      : "font-normal text-foreground"
+                  }`}
+                >
+                  {conversation.lastMessage?.trim() || "Attachment or media"}
+                </p>
+                {formatMessageAge(conversation.lastMessageTimestamp) && (
+                  <p className="mt-3 text-xs text-muted-foreground">
+                    Last activity {formatMessageAge(conversation.lastMessageTimestamp)}
+                  </p>
+                )}
+                <p className="mt-4 text-xs text-muted-foreground">
+                  The full thread will show here when it finishes loading; you can still send a reply
+                  below.
+                </p>
+              </div>
+            ) : (
+              <div className="text-center text-muted-foreground">
+                No messages yet. Start the conversation!
+              </div>
             )}
           </div>
         </div>

--- a/src/pages/MessagesInbox.tsx
+++ b/src/pages/MessagesInbox.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Search } from "lucide-react";
 import { Input } from "@/components/ui/input";
@@ -10,10 +10,17 @@ import { useMessages } from "@/hooks/useMessages";
 import { DeleteConversationForMeDialog } from "@/components/messaging/DeleteConversationForMeDialog";
 import { ConversationChatMenu } from "@/components/messaging/ConversationChatMenu";
 import { toast } from "sonner";
+import { formatDistanceToNow } from "date-fns";
 import { requestDesktopMessageNotifications } from "@/lib/messaging-notifications";
+import { useAuth } from "@/contexts/AuthContext";
+import { useOwnerBusiness } from "@/hooks/useOwnerBusiness";
+import { getConversationCounterparty, getViewerUnreadCount } from "@/lib/messaging-counterparty";
 
 const MessagesInbox = () => {
   const navigate = useNavigate();
+  const { user, isBusiness } = useAuth();
+  const { backendRow } = useOwnerBusiness();
+  const ownBusinessId = backendRow?.id ?? null;
   const [searchQuery, setSearchQuery] = useState("");
   const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
   const [deletePending, setDeletePending] = useState(false);
@@ -23,7 +30,6 @@ const MessagesInbox = () => {
     conversations,
     loading,
     error,
-    markConversationAsRead,
     hideConversationForMe,
     setConversationMuted,
   } = useMessages();
@@ -31,30 +37,32 @@ const MessagesInbox = () => {
   const showDesktopNotifPrompt =
     typeof Notification !== "undefined" && Notification.permission === "default";
 
-  const filteredConversations = conversations.filter((conv) =>
-    (conv.businessName ?? "").toLowerCase().includes(searchQuery.toLowerCase())
-  );
+  const filteredConversations = useMemo(() => {
+    const q = searchQuery.toLowerCase().trim();
+    if (!user) return conversations;
+    if (!q) return conversations;
+    return conversations.filter((conv) => {
+      const { title } = getConversationCounterparty(conv, {
+        userId: user.userId,
+        isBusiness,
+        ownBusinessId,
+      });
+      const preview = (conv.lastMessage ?? "").toLowerCase();
+      return (
+        title.toLowerCase().includes(q) ||
+        preview.includes(q)
+      );
+    });
+  }, [conversations, searchQuery, user, isBusiness, ownBusinessId]);
 
-  const formatTimestamp = (dateStr?: string | null) => {
-    if (!dateStr) return "now";
-    
-    const date = new Date(dateStr);
-    const now = new Date();
-    const diffInHours = Math.floor((now.getTime() - date.getTime()) / (1000 * 60 * 60));
-
-    if (diffInHours < 1) {
-      const diffInMinutes = Math.floor((now.getTime() - date.getTime()) / (1000 * 60));
-      return `${diffInMinutes}m ago`;
-    } else if (diffInHours < 24) {
-      return `${diffInHours}h ago`;
-    } else {
-      const diffInDays = Math.floor(diffInHours / 24);
-      return `${diffInDays}d ago`;
-    }
+  const formatRelativeTime = (dateStr?: string | null) => {
+    if (!dateStr) return null;
+    const d = new Date(dateStr);
+    if (Number.isNaN(d.getTime())) return null;
+    return formatDistanceToNow(d, { addSuffix: true });
   };
 
-  const handleConversationClick = async (conversationId: string) => {
-    await markConversationAsRead(conversationId);
+  const handleConversationClick = (conversationId: string) => {
     navigate(`/messages/${conversationId}`);
   };
 
@@ -88,7 +96,9 @@ const MessagesInbox = () => {
           <div>
             <h1 className="text-3xl font-bold text-foreground mb-2">Messages</h1>
             <p className="text-muted-foreground">
-              Chat with businesses you&apos;re interested in
+              {isBusiness
+                ? "Reply to customers who messaged your business."
+                : "Chat with businesses you&apos;re interested in."}
             </p>
             {typeof Notification !== "undefined" && Notification.permission === "granted" && (
               <p className="text-xs text-muted-foreground mt-2">Desktop notifications are enabled.</p>
@@ -144,13 +154,32 @@ const MessagesInbox = () => {
                 <p className="text-muted-foreground">Loading conversations...</p>
               </div>
             ) : filteredConversations.length > 0 ? (
-              filteredConversations.map((conversation) => (
+              filteredConversations.map((conversation) => {
+                const counterparty =
+                  user != null
+                    ? getConversationCounterparty(conversation, {
+                        userId: user.userId,
+                        isBusiness,
+                        ownBusinessId,
+                      })
+                    : { title: conversation.businessName || "Conversation", image: conversation.businessImage ?? null };
+                const timeLabel = formatRelativeTime(conversation.lastMessageTimestamp);
+                const viewerUnread =
+                  user != null
+                    ? getViewerUnreadCount(conversation, {
+                        userId: user.userId,
+                        isBusiness,
+                        ownBusinessId,
+                      })
+                    : 0;
+                const isUnread = viewerUnread > 0;
+                return (
                 <div
                   key={conversation.id}
-                  className={`relative rounded-lg border transition-all hover:shadow-md ${
-                    conversation.unreadCount > 0
-                      ? "bg-primary/5 border-primary/20"
-                      : "bg-card border-border hover:bg-accent/50"
+                  className={`relative rounded-lg border border-border transition-all hover:shadow-md ${
+                    isUnread
+                      ? "border-l-4 border-l-primary bg-primary/5 shadow-sm"
+                      : "bg-card hover:bg-accent/50"
                   }`}
                 >
                   <div className="absolute right-1 top-1 z-10">
@@ -183,49 +212,74 @@ const MessagesInbox = () => {
                     onClick={() => handleConversationClick(conversation.id)}
                     className="flex w-full min-w-0 items-start gap-4 p-4 pr-14 pt-10 text-left hover:bg-accent/30 sm:pt-4"
                   >
-                    <Avatar className="h-14 w-14 shrink-0">
-                      <AvatarImage
-                        src={conversation.businessImage || undefined}
-                        alt={conversation.businessName || "Business"}
-                      />
-                      <AvatarFallback>{(conversation.businessName || "B")[0]}</AvatarFallback>
-                    </Avatar>
+                    <div
+                      className={`relative shrink-0 ${isUnread ? "ring-2 ring-primary/35 ring-offset-2 ring-offset-background rounded-full" : ""}`}
+                    >
+                      <Avatar className="h-14 w-14">
+                        <AvatarImage
+                          src={counterparty.image || undefined}
+                          alt={counterparty.title}
+                        />
+                        <AvatarFallback>{(counterparty.title || "C")[0]}</AvatarFallback>
+                      </Avatar>
+                      {isUnread && (
+                        <span
+                          className="absolute -right-0.5 -top-0.5 flex h-3.5 w-3.5 items-center justify-center rounded-full border-2 border-background bg-primary shadow-sm"
+                          title="Unread messages"
+                          aria-hidden
+                        />
+                      )}
+                    </div>
 
                     <div className="flex-1 min-w-0 text-left">
-                      <div className="flex items-center gap-2 mb-1">
+                      <div className="mb-1 flex items-center gap-2">
                         <h3
-                          className={`font-semibold truncate ${
-                            conversation.unreadCount > 0 ? "text-foreground font-bold" : "text-foreground"
+                          className={`truncate ${
+                            isUnread
+                              ? "text-base font-bold text-foreground"
+                              : "text-base font-semibold text-foreground"
                           }`}
                         >
-                          {conversation.businessName || "Conversation"}
+                          {counterparty.title}
                         </h3>
                       </div>
 
                       <p
-                        className={`text-sm truncate ${
-                          conversation.unreadCount > 0
-                            ? "font-medium text-foreground"
-                            : "text-muted-foreground"
+                        className={`truncate text-sm leading-snug ${
+                          isUnread
+                            ? "font-bold text-foreground"
+                            : "font-normal text-muted-foreground"
                         }`}
                       >
-                        {conversation.lastMessage || "No messages yet"}
+                        {conversation.lastMessage?.trim() ||
+                          (conversation.lastMessageTimestamp
+                            ? "Attachment or media"
+                            : "No messages yet")}
                       </p>
                     </div>
 
                     <div className="shrink-0 flex flex-col items-end gap-2 pt-1">
-                      <span className="text-xs text-muted-foreground">
-                        {formatTimestamp(conversation.lastMessageTimestamp)}
-                      </span>
-                      {conversation.unreadCount > 0 && (
+                      {timeLabel ? (
+                        <span
+                          className={`text-xs ${
+                            isUnread ? "font-semibold text-primary" : "text-muted-foreground"
+                          }`}
+                        >
+                          {timeLabel}
+                        </span>
+                      ) : (
+                        <span className="text-xs text-muted-foreground opacity-50">—</span>
+                      )}
+                      {viewerUnread > 0 && (
                         <div className="flex items-center justify-center h-6 w-6 rounded-full bg-primary text-primary-foreground text-xs font-semibold">
-                          {conversation.unreadCount > 99 ? "99+" : conversation.unreadCount}
+                          {viewerUnread > 99 ? "99+" : viewerUnread}
                         </div>
                       )}
                     </div>
                   </button>
                 </div>
-              ))
+                );
+              })
             ) : (
               <div className="text-center py-12">
                 <p className="text-muted-foreground">No conversations found</p>

--- a/src/pages/MessagesInbox.tsx
+++ b/src/pages/MessagesInbox.tsx
@@ -1,17 +1,35 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Search } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Navigation } from "@/components/Navigation";
 import { useMessages } from "@/hooks/useMessages";
+import { DeleteConversationForMeDialog } from "@/components/messaging/DeleteConversationForMeDialog";
+import { ConversationChatMenu } from "@/components/messaging/ConversationChatMenu";
+import { toast } from "sonner";
+import { requestDesktopMessageNotifications } from "@/lib/messaging-notifications";
 
 const MessagesInbox = () => {
   const navigate = useNavigate();
   const [searchQuery, setSearchQuery] = useState("");
-  const { conversations, loading, error, markConversationAsRead } = useMessages();
+  const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
+  const [deletePending, setDeletePending] = useState(false);
+  const [muteBusyId, setMuteBusyId] = useState<string | null>(null);
+  const [desktopNotifBusy, setDesktopNotifBusy] = useState(false);
+  const {
+    conversations,
+    loading,
+    error,
+    markConversationAsRead,
+    hideConversationForMe,
+    setConversationMuted,
+  } = useMessages();
+
+  const showDesktopNotifPrompt =
+    typeof Notification !== "undefined" && Notification.permission === "default";
 
   const filteredConversations = conversations.filter((conv) =>
     (conv.businessName ?? "").toLowerCase().includes(searchQuery.toLowerCase())
@@ -43,13 +61,63 @@ const MessagesInbox = () => {
   return (
     <div className="min-h-screen bg-background">
       <Navigation />
-      
+      <DeleteConversationForMeDialog
+        open={deleteTargetId !== null}
+        onOpenChange={(open) => {
+          if (!open) setDeleteTargetId(null);
+        }}
+        pending={deletePending}
+        onConfirm={async () => {
+          if (!deleteTargetId) return;
+          setDeletePending(true);
+          try {
+            await hideConversationForMe(deleteTargetId);
+          } catch (err) {
+            toast.error("Couldn't remove chat", {
+              description: err instanceof Error ? err.message : undefined,
+            });
+            throw err;
+          } finally {
+            setDeletePending(false);
+          }
+        }}
+      />
+
       <div className="container max-w-4xl mx-auto px-4 py-8">
-        <div className="mb-6">
-          <h1 className="text-3xl font-bold text-foreground mb-2">Messages</h1>
-          <p className="text-muted-foreground">
-            Chat with businesses you're interested in
-          </p>
+        <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <h1 className="text-3xl font-bold text-foreground mb-2">Messages</h1>
+            <p className="text-muted-foreground">
+              Chat with businesses you&apos;re interested in
+            </p>
+            {typeof Notification !== "undefined" && Notification.permission === "granted" && (
+              <p className="text-xs text-muted-foreground mt-2">Desktop notifications are enabled.</p>
+            )}
+          </div>
+          {showDesktopNotifPrompt && (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="shrink-0 self-start"
+              disabled={desktopNotifBusy}
+              onClick={async () => {
+                setDesktopNotifBusy(true);
+                try {
+                  const p = await requestDesktopMessageNotifications();
+                  if (p === "granted") {
+                    toast.success("Desktop notifications enabled");
+                  } else if (p === "denied") {
+                    toast.error("Notifications are blocked in your browser settings.");
+                  }
+                } finally {
+                  setDesktopNotifBusy(false);
+                }
+              }}
+            >
+              {desktopNotifBusy ? "Requesting…" : "Enable desktop alerts"}
+            </Button>
+          )}
         </div>
 
         {/* Search Bar */}
@@ -77,16 +145,44 @@ const MessagesInbox = () => {
               </div>
             ) : filteredConversations.length > 0 ? (
               filteredConversations.map((conversation) => (
-                <button
+                <div
                   key={conversation.id}
-                  onClick={() => handleConversationClick(conversation.id)}
-                  className={`w-full p-4 rounded-lg border transition-all hover:shadow-md ${
+                  className={`relative rounded-lg border transition-all hover:shadow-md ${
                     conversation.unreadCount > 0
                       ? "bg-primary/5 border-primary/20"
                       : "bg-card border-border hover:bg-accent/50"
                   }`}
                 >
-                  <div className="flex items-start gap-4">
+                  <div className="absolute right-1 top-1 z-10">
+                    <ConversationChatMenu
+                      openable
+                      participantMuted={conversation.participantMuted}
+                      muteBusy={muteBusyId === conversation.id}
+                      onToggleMute={async () => {
+                        try {
+                          setMuteBusyId(conversation.id);
+                          await setConversationMuted(conversation.id, !conversation.participantMuted);
+                          toast.success(
+                            conversation.participantMuted
+                              ? "Conversation unmuted"
+                              : "Conversation muted — alerts paused for this chat"
+                          );
+                        } catch (e) {
+                          toast.error("Could not update mute", {
+                            description: e instanceof Error ? e.message : undefined,
+                          });
+                        } finally {
+                          setMuteBusyId(null);
+                        }
+                      }}
+                      onRequestDelete={() => setDeleteTargetId(conversation.id)}
+                    />
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => handleConversationClick(conversation.id)}
+                    className="flex w-full min-w-0 items-start gap-4 p-4 pr-14 pt-10 text-left hover:bg-accent/30 sm:pt-4"
+                  >
                     <Avatar className="h-14 w-14 shrink-0">
                       <AvatarImage
                         src={conversation.businessImage || undefined}
@@ -117,7 +213,7 @@ const MessagesInbox = () => {
                       </p>
                     </div>
 
-                    <div className="shrink-0 flex flex-col items-end gap-2">
+                    <div className="shrink-0 flex flex-col items-end gap-2 pt-1">
                       <span className="text-xs text-muted-foreground">
                         {formatTimestamp(conversation.lastMessageTimestamp)}
                       </span>
@@ -127,8 +223,8 @@ const MessagesInbox = () => {
                         </div>
                       )}
                     </div>
-                  </div>
-                </button>
+                  </button>
+                </div>
               ))
             ) : (
               <div className="text-center py-12">


### PR DESCRIPTION
## Summary

Adds **business-scoped messaging**: inbox + thread UI, draft new threads, mute and hide-for-me, search, unread handling, optional desktop notifications, and Amplify schema/output updates so the client matches the backend. 

**Base:** `dev`

## Files

| File | Notes |
|------|--------|
| `amplify/data/resource.ts` | Data schema updates for messaging-related models/APIs |
| `amplify_outputs.json` | Regenerated Amplify client config |
| `src/App.tsx` | Global messaging listener / app shell wiring |
| `src/components/messaging/ConversationChatMenu.tsx` | **New** — per-thread menu actions |
| `src/components/messaging/DeleteConversationForMeDialog.tsx` | **New** — confirm hide/delete-for-me |
| `src/components/messaging/MessageNotificationListener.tsx` | **New** — message events → notifications |
| `src/hooks/useMessages.ts` | Conversations, send, read, mute, hide, drafts, etc. |
| `src/lib/messaging-counterparty.ts` | **New** — counterparty + unread for customer vs business |
| `src/lib/messaging-events.ts` | Event constant(s) for refresh |
| `src/lib/messaging-notifications.ts` | Desktop notification helpers |
| `src/lib/format-display-name.ts` | **New** — display name formatting |
| `src/pages/Messages.tsx` | Thread view + routing + compose |
| `src/pages/MessagesInbox.tsx` | Inbox, search, mute/hide, notification prompt |
| `src/pages/BusinessProfile.tsx` | Messaging entry from profile |
| `src/components/business-profile/BusinessProfileLayout.tsx` | Layout tweaks |
| `src/components/business-profile/ReviewForm.tsx` | Minor display/name alignment |
